### PR TITLE
[add] #36 CalendarCellの追加

### DIFF
--- a/app/src/main/java/jp/ac/meijou/s231205036/android/schedulestrengthcalendar/CalendarActivity.java
+++ b/app/src/main/java/jp/ac/meijou/s231205036/android/schedulestrengthcalendar/CalendarActivity.java
@@ -26,7 +26,6 @@ import androidx.core.view.WindowInsetsCompat;
 
 import jp.ac.meijou.s231205036.android.schedulestrengthcalendar.databinding.ActivityCalendarBinding;
 
-
 public class CalendarActivity extends AppCompatActivity {
     private ActivityCalendarBinding binding;
 
@@ -155,7 +154,8 @@ public class CalendarActivity extends AppCompatActivity {
             default -> firstDay;
         };
 
-        int yesterdayBusy = 0;
+        CalendarCell cell = new CalendarCell(0, 0);
+
         for (int i = 0; i < 42; i++) {
             LinearLayout linearLayout = findViewById(i);
             linearLayout.removeAllViews();  // 全てのビューをクリア
@@ -213,7 +213,11 @@ public class CalendarActivity extends AppCompatActivity {
                 if (task.isSuccessful()) {
                     if (task.getResult().exists()) {
                         String data = task.getResult().getString("タイトル");
-                        viewBusy(yesterdayBusy, Integer.valueOf(task.getResult().getString("強度")), linearLayout);
+
+                        //忙しさ表示
+                        //viewBusy(Integer.valueOf(task.getResult().getString("強度")), linearLayout, CalendarCell);
+                        cell.setday1Busy(Integer.valueOf(task.getResult().getString("強度")));
+                        viewBusy(linearLayout, cell);
 
                         Button button = new Button(this);
                         button.setText(data);
@@ -236,10 +240,12 @@ public class CalendarActivity extends AppCompatActivity {
         }
     }
 
-    //忙しさの表示
-    private int viewBusy(final int yesterdayBusy,final int todayBusy, final LinearLayout ll) {
-        int busy = todayBusy;
-
+    //忙しさ表示関数
+    private void viewBusy(final LinearLayout ll, CalendarCell cell) {
+        int busy = cell.getday1Busy() + cell.getday0Busy() % 2;
+        if(busy > 7){
+            busy = 7;
+        }
         switch (busy) {
             case 7 -> ll.setBackgroundColor(Color.rgb(157, 73, 255));
             case 6 -> ll.setBackgroundColor(Color.rgb(255, 73, 73));
@@ -249,7 +255,8 @@ public class CalendarActivity extends AppCompatActivity {
             case 2 -> ll.setBackgroundColor(Color.rgb(73, 255, 146));
             case 1 -> ll.setBackgroundColor(Color.rgb(73, 255, 233));
             case 0 -> ll.setBackgroundColor(Color.rgb(188, 188, 188));
+            default -> ll.setBackgroundColor(Color.rgb(0,0,0));
         }
-        return busy;
+        //cell.shiftBusy();
     }
 }

--- a/app/src/main/java/jp/ac/meijou/s231205036/android/schedulestrengthcalendar/CalendarCell.java
+++ b/app/src/main/java/jp/ac/meijou/s231205036/android/schedulestrengthcalendar/CalendarCell.java
@@ -1,0 +1,32 @@
+package jp.ac.meijou.s231205036.android.schedulestrengthcalendar;
+
+public class CalendarCell {
+    private int day0Busy;
+    private int day1Busy;
+
+    public CalendarCell(int day0Busy, int day1Busy) {
+        this.setday0Busy(day0Busy);   //1日前のBusy
+        this.setday1Busy(day1Busy);   //当日のBusy
+    }
+
+    public int getday0Busy() {
+        return this.day0Busy;
+    }
+
+    public void setday0Busy(int day0Busy) {
+        this.day0Busy = day0Busy;
+    }
+
+    public int getday1Busy() {
+        return this.day1Busy;
+    }
+
+    public void setday1Busy(int day1Busy) {
+        this.day1Busy = day1Busy;
+    }
+
+    public void shiftBusy(){
+        this.setday0Busy(this.getday1Busy());
+    }
+}
+


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

## 概要

<!-- 変更の目的 もしくは 関連する Issue 番号 -->
- #36 CalendarCellの追加
- まだ前日の忙しさを反映できない

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- CalendarCell,javaを追加
- CalendarActivity.javaにおいて、忙しさの表示をCalendarCellに対応

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
- firestoreが非同期であるため上手くいかない。(sqlになったときに再検討)
- 42個のオブジェクトを作ればなんとかなるかも