### PR TITLE
[add] #48 予定詳細表示の実装

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,26 +13,26 @@
         android:theme="@style/Theme.ScheduleStrengthCalendar"
         tools:targetApi="31">
         <activity
+            android:name=".EditScheduleActivity"
+            android:exported="false" />
+        <activity
             android:name=".SettingActivity"
             android:exported="false" />
         <activity
             android:name=".AddScheduleActivity"
-            android:exported="true">
-
-        </activity>
+            android:exported="true"></activity>
         <activity
             android:name=".CalendarActivity"
             android:exported="true" />
         <activity
             android:name=".MainActivity"
-            android:exported="true" >
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-
     </application>
 
 </manifest>

--- a/app/src/main/java/jp/ac/meijou/s231205036/android/schedulestrengthcalendar/EditScheduleActivity.java
+++ b/app/src/main/java/jp/ac/meijou/s231205036/android/schedulestrengthcalendar/EditScheduleActivity.java
@@ -1,0 +1,187 @@
+package jp.ac.meijou.s231205036.android.schedulestrengthcalendar;
+
+import android.annotation.SuppressLint;
+import android.app.DatePickerDialog;
+import android.app.TimePickerDialog;
+import android.os.Bundle;
+import android.view.MotionEvent;
+import android.view.WindowManager;
+import android.widget.ArrayAdapter;
+import android.widget.EditText;
+
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.app.AppCompatActivity;
+import com.google.firebase.firestore.FirebaseFirestore;
+
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.Map;
+import jp.ac.meijou.s231205036.android.schedulestrengthcalendar.databinding.ActivityAddScheduleBinding;
+
+public class EditScheduleActivity extends AppCompatActivity {
+
+    private ActivityAddScheduleBinding binding;
+    private FirebaseFirestore db;
+
+    private int selectedYear, selectedMonth, selectedDay;
+
+    @SuppressLint("ClickableViewAccessibility")
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        binding = ActivityAddScheduleBinding.inflate(getLayoutInflater());
+        setContentView(binding.getRoot());
+
+        // Firestore インスタンスを取得
+        db = FirebaseFirestore.getInstance();
+
+        // Button名を変更
+        binding.save.setText("変更を適用");
+        binding.back.setText("キャンセル");
+
+        // Spinner の設定
+        String[] strongOptions = {"1","2", "3", "4", "5"};
+        var adapter = new ArrayAdapter<>(this, android.R.layout.simple_spinner_item, strongOptions);
+        adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        binding.spinnerNumber.setAdapter(adapter);
+
+        String[] repeatOptions = {"なし", "毎週", "隔週", "毎月"};
+        var repeatAdapter = new ArrayAdapter<>(this, android.R.layout.simple_spinner_item, repeatOptions);
+        repeatAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        binding.answer.setAdapter(repeatAdapter);
+
+        binding.inputDate.setOnClickListener(view -> showDatePickerDialog());
+        binding.TimeFirst.setOnClickListener(view -> showTimePickerDialog(binding.TimeFirst));
+        binding.TimeFinal.setOnClickListener(view -> showTimePickerDialog(binding.TimeFinal));
+
+        binding.back.setOnClickListener(view -> {
+            finish(); // 現在のアクティビティを終了して前の画面に戻る
+        });
+
+        binding.TimeFirst.setOnTouchListener((v, event) -> {
+            if (event.getAction() == MotionEvent.ACTION_UP) {
+                showTimePickerDialog(binding.TimeFirst);
+                return true;
+            }
+            return false;
+        });
+
+        binding.TimeFinal.setOnTouchListener((v, event) -> {
+            if (event.getAction() == MotionEvent.ACTION_UP) {
+                showTimePickerDialog(binding.TimeFinal);
+                return true;
+            }
+            return false;
+        });
+
+        binding.inputDate.setOnTouchListener((v, event) -> {
+            if (event.getAction() == MotionEvent.ACTION_UP) {
+                showDatePickerDialog();
+                return true;
+            }
+            return false;
+        });
+
+
+
+
+        // 変更ボタンのクリックイベント
+        binding.save.setOnClickListener(view -> {
+            var title = binding.inputText.getText().toString();
+            var startTime = binding.TimeFirst.getText().toString();
+            var endTime = binding.TimeFinal.getText().toString();
+            var memo = binding.memo.getText().toString();
+            var answer = binding.answer.getSelectedItem().toString();
+            var intensity = binding.spinnerNumber.getSelectedItem().toString();
+
+            // Firestore に保存するデータを作成
+            Map<String, Object> scheduleData = new HashMap<>();
+            scheduleData.put("タイトル", title);
+            scheduleData.put("開始時間", startTime);
+            scheduleData.put("終了時間", endTime);
+            scheduleData.put("強度", intensity);
+            scheduleData.put("メモ", memo);
+            scheduleData.put("繰り返し", answer);
+
+            // 日付データを追加 (後で変数化)
+            String collectionName = "aaa"; // 他のコレクションと被らない名前
+            String year = String.valueOf(selectedYear);
+            String month = String.valueOf(selectedMonth);
+            String day = String.valueOf(selectedDay);  // ここに日付の変数を追加
+
+            // Firestore にデータを保存
+            saveDataToFirestore(collectionName, year, month, day, scheduleData);
+
+            // メッセージの表示
+            var message = "タイトル : " + title + "\n日付 : "+year + "/" + month + "/" + day + "\n開始時間 : " + startTime + "\n終了時間 : " + endTime +
+                    "\n強度 : " + intensity + "\nメモ : " + memo + "\n繰り返し : " + answer;
+            showConfirmationDialog(message);
+        });
+    }
+
+    private void showConfirmationDialog(String message) {
+        AlertDialog.Builder builder = new AlertDialog.Builder(this);
+        builder.setTitle("確認")
+                .setMessage(message)
+                .setPositiveButton("OK", (dialog, which) -> dialog.dismiss())
+                .setCancelable(true);
+
+        AlertDialog dialog = builder.create();
+        dialog.show();
+
+        dialog.getWindow().setLayout(
+                (int) (getResources().getDisplayMetrics().widthPixels * 0.9),
+                WindowManager.LayoutParams.WRAP_CONTENT
+        );
+    }
+
+    private void showDatePickerDialog() {
+
+        Calendar calendar = Calendar.getInstance();
+        int year = calendar.get(Calendar.YEAR);
+        int month = calendar.get(Calendar.MONTH);
+        int day = calendar.get(Calendar.DAY_OF_MONTH);
+
+        DatePickerDialog datePickerDialog = new DatePickerDialog(this, (view, selectedYear, selectedMonth, selectedDay) -> {
+
+            this.selectedYear = selectedYear;
+            this.selectedMonth = selectedMonth + 1;
+            this.selectedDay = selectedDay;
+
+            binding.inputDate.setText(selectedYear + "/" + this.selectedMonth + "/" + this.selectedDay);
+        }, year, month, day);
+
+        datePickerDialog.show();
+    }
+
+
+    // Firestore にデータを保存するメソッド
+    public void saveDataToFirestore(String collectionName, String documentYear, String month, String day, Map<String, Object> data) {
+        db.collection(collectionName)
+                .document(documentYear)
+                .collection(month)
+                .document(day)
+                .set(data)
+                .addOnSuccessListener(aVoid -> {
+                    System.out.println("Data successfully saved!");
+                })
+                .addOnFailureListener(e -> {
+                    System.err.println("Error saving data: " + e.getMessage());
+                });
+    }
+
+    private void showTimePickerDialog(final EditText editText) {
+        Calendar calendar = Calendar.getInstance();
+        int hour = calendar.get(Calendar.HOUR_OF_DAY);
+        int minute = calendar.get(Calendar.MINUTE);
+
+        TimePickerDialog timePickerDialog = new TimePickerDialog(this,
+                (view, selectedHour, selectedMinute) -> {
+                    String time = String.format("%2d:%02d", selectedHour, selectedMinute);
+                    editText.setText(time);
+                }, hour, minute, true); // 'true' for 24-hour format
+
+        timePickerDialog.show();
+    }
+
+}

--- a/app/src/main/res/drawable/ic_cancel.xml
+++ b/app/src/main/res/drawable/ic_cancel.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#666666" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M12,2C6.47,2 2,6.47 2,12s4.47,10 10,10 10,-4.47 10,-10S17.53,2 12,2zM17,15.59L15.59,17 12,13.41 8.41,17 7,15.59 10.59,12 7,8.41 8.41,7 12,10.59 15.59,7 17,8.41 13.41,12 17,15.59z"/>
+    
+</vector>

--- a/app/src/main/res/drawable/ic_delete.xml
+++ b/app/src/main/res/drawable/ic_delete.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#666666" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M6,19c0,1.1 0.9,2 2,2h8c1.1,0 2,-0.9 2,-2V7H6v12zM19,4h-3.5l-1,-1h-5l-1,1H5v2h14V4z"/>
+    
+</vector>

--- a/app/src/main/res/drawable/ic_edit.xml
+++ b/app/src/main/res/drawable/ic_edit.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#666666" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M3,17.25V21h3.75L17.81,9.94l-3.75,-3.75L3,17.25zM20.71,7.04c0.39,-0.39 0.39,-1.02 0,-1.41l-2.34,-2.34c-0.39,-0.39 -1.02,-0.39 -1.41,0l-1.83,1.83 3.75,3.75 1.83,-1.83z"/>
+    
+</vector>

--- a/app/src/main/res/layout/dialog_detail_layout.xml
+++ b/app/src/main/res/layout/dialog_detail_layout.xml
@@ -1,0 +1,98 @@
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="32dp"
+    tools:context=".CalendarActivity">
+
+    <TextView
+        android:id="@+id/strong"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="①"
+        android:textSize="20dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
+
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="8dp"
+        android:hint="タイトルを追加"
+        android:textSize="20dp"
+        app:layout_constraintStart_toEndOf="@id/strong"
+        app:layout_constraintTop_toTopOf="@+id/strong" />
+
+    <TextView
+        android:id="@+id/date"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="18dp"
+        android:hint="YYYY/MM/DD"
+        app:layout_constraintBottom_toTopOf="@+id/memo"
+        app:layout_constraintEnd_toStartOf="@id/time"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/title" />
+
+    <TextView
+        android:id="@+id/time"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:hint="XX:XX ~ XX:XX"
+        app:layout_constraintEnd_toStartOf="@id/repeat"
+        app:layout_constraintStart_toEndOf="@id/date"
+        app:layout_constraintTop_toTopOf="@+id/date" />
+
+    <TextView
+        android:id="@+id/repeat"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:hint="繰り返し：なし"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/time"
+        app:layout_constraintTop_toTopOf="@+id/date" />
+
+    <TextView
+        android:id="@+id/memo"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_marginTop="16dp"
+        android:hint="説明を追加"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/date" />
+
+    <ImageButton
+        android:id="@+id/buttonEdit"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="16dp"
+        android:src="@drawable/ic_edit"
+        android:background="@color/white"
+        app:layout_constraintEnd_toStartOf="@id/buttonDelete"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <ImageButton
+        android:id="@+id/buttonDelete"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="16dp"
+        android:src="@drawable/ic_delete"
+        android:background="@color/white"
+        app:layout_constraintEnd_toStartOf="@id/buttonCancel"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <ImageButton
+        android:id="@+id/buttonCancel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@drawable/ic_cancel"
+        android:background="@color/white"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

## 概要

<!-- 変更の目的 もしくは 関連する Issue 番号 -->
- #48 予定詳細表示の実装

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- ボタンを押した際に、詳細を表示したダイアログが開き、予定の編集、削除、ダイアログを閉じる、ボタンを搭載
- 編集ボタンは新規作成したEditScheduleActivityへ遷移→内容は未実装（AddScheduleActivityとほぼ同一）
- 削除ボタンは押すと確認ダイアログが開き、データベースから予定を削除可能

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->
- EditScheduleActivityは、activity_add_schedule.xmlを使用しています。変更を加えるとこちらも変更されるため、注意が必要。

## 動作要件

<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
- x

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
- x