### PR TITLE
[add] #49 同日に予定を追加可能にDBを変更

### DIFF
--- a/app/src/main/java/jp/ac/meijou/s231205036/android/schedulestrengthcalendar/AddScheduleActivity.java
+++ b/app/src/main/java/jp/ac/meijou/s231205036/android/schedulestrengthcalendar/AddScheduleActivity.java
@@ -78,9 +78,6 @@ public class AddScheduleActivity extends AppCompatActivity {
             return false;
         });
 
-
-
-
         // 保存ボタンのクリックイベント
         binding.save.setOnClickListener(view -> {
             var title = binding.inputText.getText().toString();
@@ -100,18 +97,18 @@ public class AddScheduleActivity extends AppCompatActivity {
             scheduleData.put("繰り返し", answer);
 
             // 日付データを追加 (後で変数化)
-            String collectionName = "aaa"; // 他のコレクションと被らない名前
             String year = String.valueOf(selectedYear);
             String month = String.valueOf(selectedMonth);
-            String day = String.valueOf(selectedDay);  // ここに日付の変数を追加
+            String date = String.valueOf(selectedDay);
 
             // Firestore にデータを保存
-            saveDataToFirestore(collectionName, year, month, day, scheduleData);
+            saveDataToFirestore(year, month, date, scheduleData);
 
             // メッセージの表示
-            var message = "タイトル : " + title + "\n日付 : "+year + "/" + month + "/" + day + "\n開始時間 : " + startTime + "\n終了時間 : " + endTime +
+            var message = "タイトル : " + title + "\n日付 : "+year + "/" + month + "/" + date + "\n開始時間 : " + startTime + "\n終了時間 : " + endTime +
                     "\n強度 : " + intensity + "\nメモ : " + memo + "\n繰り返し : " + answer;
             showConfirmationDialog(message);
+            finish(); // 現在のアクティビティを終了して前の画面に戻る
         });
     }
 
@@ -152,12 +149,11 @@ public class AddScheduleActivity extends AppCompatActivity {
 
 
     // Firestore にデータを保存するメソッド
-    public void saveDataToFirestore(String collectionName, String documentYear, String month, String day, Map<String, Object> data) {
-        db.collection(collectionName)
-                .document(documentYear)
-                .collection(month)
-                .document(day)
-                .set(data)
+    public void saveDataToFirestore(String documentYear, String month, String date, Map<String, Object> data) {
+        db.collection(documentYear)
+                .document(month)
+                .collection(date)
+                .add(data)
                 .addOnSuccessListener(aVoid -> {
                     System.out.println("Data successfully saved!");
                 })

--- a/app/src/main/java/jp/ac/meijou/s231205036/android/schedulestrengthcalendar/CalendarActivity.java
+++ b/app/src/main/java/jp/ac/meijou/s231205036/android/schedulestrengthcalendar/CalendarActivity.java
@@ -25,9 +25,11 @@ import android.widget.TextView;
 
 import java.util.Calendar;
 
+import com.google.firebase.firestore.CollectionReference;
 import com.google.firebase.firestore.DocumentReference;
 import com.google.firebase.firestore.FieldValue;
 import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.QueryDocumentSnapshot;
 
 import androidx.activity.EdgeToEdge;
 import androidx.appcompat.app.AppCompatActivity;
@@ -158,7 +160,6 @@ public class CalendarActivity extends AppCompatActivity {
         // カレンダーの初期化
         Calendar calendar = Calendar.getInstance();
         calendar.set(year, month, 1);
-        String name = "aaa";
         int firstDay = 0;
 
         // カレンダーの最初の曜日を決定
@@ -190,14 +191,14 @@ public class CalendarActivity extends AppCompatActivity {
                 date += calendar.getActualMaximum(Calendar.DAY_OF_MONTH);
                 addDate(frameLayout,linearLayout,date,true);
                 calendar.add(Calendar.MONTH, 1);
-                addSchedule(frameLayout,linearLayout,name,year,month-1,date,yesterdayBusy);
+                addSchedule(frameLayout,linearLayout,year,month-1,date,yesterdayBusy);
             } else if (date > calendar.getActualMaximum(Calendar.DAY_OF_MONTH)) {
                 date -= calendar.getActualMaximum(Calendar.DAY_OF_MONTH);
                 addDate(frameLayout,linearLayout,date,true);
-                addSchedule(frameLayout,linearLayout,name,year,month+1,date,yesterdayBusy);
+                addSchedule(frameLayout,linearLayout,year,month+1,date,yesterdayBusy);
             } else {
                 addDate(frameLayout,linearLayout,date,false);
-                addSchedule(frameLayout,linearLayout,name,year,month,date,yesterdayBusy);
+                addSchedule(frameLayout,linearLayout,year,month,date,yesterdayBusy);
             }
         }
     }
@@ -232,20 +233,24 @@ public class CalendarActivity extends AppCompatActivity {
     }
 
     // 予定の表示
-    private void addSchedule(FrameLayout frameLayout, LinearLayout linearLayout, String name, int year, int month, int date, int yesterdayBusy) {
+    private void addSchedule(FrameLayout frameLayout, LinearLayout linearLayout, int year, int month, int date, int yesterdayBusy) {
         FirebaseFirestore db = FirebaseFirestore.getInstance();
-        String documentPath = name + "/" + year + "/" + (month+1) + "/" + date;
-        DocumentReference calendarRef = db.document(documentPath);
+        String collectionPath = year + "/" + (month + 1) + "/" + date;
+        CollectionReference calendarRef = db.collection(collectionPath);
 
         calendarRef.get().addOnCompleteListener(task -> {
             if (task.isSuccessful()) {
-                if (task.getResult().exists()) {
-                    String title = task.getResult().getString("タイトル");
-                    String startTime = task.getResult().getString("開始時間");
-                    String endTime = task.getResult().getString("終了時間");
-                    String strong = task.getResult().getString("強度");
-                    String memo = task.getResult().getString("メモ");
-                    String repeat = task.getResult().getString("繰り返し");
+                for (QueryDocumentSnapshot document : task.getResult()) {
+                    // ここでドキュメントIDを取得し、その中のフィールドを取得する
+                    String documentID = document.getId();  // 一意のdocumentID
+
+                    // 予定の各フィールドを取得
+                    String title = document.getString("タイトル");
+                    String startTime = document.getString("開始時間");
+                    String endTime = document.getString("終了時間");
+                    String strong = document.getString("強度");
+                    String memo = document.getString("メモ");
+                    String repeat = document.getString("繰り返し");
 
                     viewBusy(yesterdayBusy, Integer.valueOf(strong), linearLayout);
 
@@ -293,7 +298,7 @@ public class CalendarActivity extends AppCompatActivity {
                         buttonEdit.setOnClickListener(edit -> {
                             // Intent を作成して EditSchedule へ遷移
                             Intent intent = new Intent(CalendarActivity.this, EditScheduleActivity.class);
-                            intent.putExtra("path",documentPath);
+                            intent.putExtra("collectionPath", documentID);
                             startActivity(intent);
                         });
 
@@ -302,8 +307,7 @@ public class CalendarActivity extends AppCompatActivity {
                             builder2.setTitle("予定を削除しますか？")
                             .setPositiveButton("削除", (dialog2, which) -> {
                                 // 削除し、ダイアログを閉じる
-                                db.document(documentPath)
-                                        .delete();
+                                db.collection(collectionPath).document(documentID).delete();
                                 dialog.dismiss();
                                 refreshCalendarData(year, month);
                             })


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

## 概要

<!-- 変更の目的 もしくは 関連する Issue 番号 -->
- #49 1日に複数の予定が登録できるよう変更

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- 同日の予定が登録できるようDB構成を変更し、それに応じて、カレンダー表示、予定追加、予定編集のDB接続部分も修正
- DBは、ユーザ名をなくし、日にちの下に用意した、一意のIDを持ったドキュメント内で管理
- {年(collection)}＞{月(document)}＞{日(collection)}＞{ドキュメントID(document)}＞field(これまで同様)

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->
- DB構成を変更しているため、DB接続部分各所に影響が出ると思われます。
- これまでに登録したデータに干渉することはないため、今までのプログラムを動かす分には問題ないと思います。

## 動作要件

<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
- DBの更新は変更内容の通り

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
- DB構成の変更に注意