### PR TITLE
Add/#36 add busy data

### DIFF
--- a/app/src/main/java/jp/ac/meijou/s231205036/android/schedulestrengthcalendar/BusyData.java
+++ b/app/src/main/java/jp/ac/meijou/s231205036/android/schedulestrengthcalendar/BusyData.java
@@ -4,9 +4,9 @@ public class BusyData {
     private int day0Busy;   //1日前のBusy
     private int day1Busy;   //当日のBusy
 
-    public BusyData(int day0Busy, int day1Busy) {
-        this.setDay0Busy(day0Busy);
-        this.setDay1Busy(day1Busy);
+    public BusyData() {
+        this.setDay0Busy(0);
+        this.setDay1Busy(0);
     }
 
     public int getDay0Busy() {
@@ -23,9 +23,5 @@ public class BusyData {
 
     public void setDay1Busy(int day1Busy) {
         this.day1Busy = day1Busy;
-    }
-
-    public void shiftBusy(){
-        this.setDay0Busy(this.getDay1Busy());
     }
 }

--- a/app/src/main/java/jp/ac/meijou/s231205036/android/schedulestrengthcalendar/BusyData.java
+++ b/app/src/main/java/jp/ac/meijou/s231205036/android/schedulestrengthcalendar/BusyData.java
@@ -1,0 +1,31 @@
+package jp.ac.meijou.s231205036.android.schedulestrengthcalendar;
+
+public class BusyData {
+    private int day0Busy;   //1日前のBusy
+    private int day1Busy;   //当日のBusy
+
+    public BusyData(int day0Busy, int day1Busy) {
+        this.setDay0Busy(day0Busy);
+        this.setDay1Busy(day1Busy);
+    }
+
+    public int getDay0Busy() {
+        return this.day0Busy;
+    }
+
+    public void setDay0Busy(int day0Busy) {
+        this.day0Busy = day0Busy;
+    }
+
+    public int getDay1Busy() {
+        return this.day1Busy;
+    }
+
+    public void setDay1Busy(int day1Busy) {
+        this.day1Busy = day1Busy;
+    }
+
+    public void shiftBusy(){
+        this.setDay0Busy(this.getDay1Busy());
+    }
+}


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

## 概要

<!-- 変更の目的 もしくは 関連する Issue 番号 -->
- 前日の忙しさを踏まえた忙しさを表示できるようにした

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- BusyData.javaで忙しさのクラスを管理
- BusyDataクラスを42(計算時にオーバーするので今は43)個、作成したものを用いる
- firestoreが非同期処理で動くため、firestoreの読み取りが終わってから色を変える

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
- 今は忙しさのみクラスに保存しているが、ほかのデータ(日付など)もフィールドに含めたクラスを作成するべきかもしれない