### PR TITLE
[change] #50 OnResumeでヘッダーの月表示を現在の月にリセット

### DIFF
--- a/app/src/main/java/jp/ac/meijou/s231205036/android/schedulestrengthcalendar/CalendarActivity.java
+++ b/app/src/main/java/jp/ac/meijou/s231205036/android/schedulestrengthcalendar/CalendarActivity.java
@@ -109,6 +109,9 @@ public class CalendarActivity extends AppCompatActivity {
         Calendar calendar = Calendar.getInstance();  // 現在のカレンダーを取得
         TableLayout tableLayout = findViewById(R.id.calender);
 
+        // 現在の年と月を取得して headerText に設定
+        updateHeaderText(calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH));
+
         // 重複してカレンダーが生成されないようにビューをクリア
         tableLayout.removeAllViews();
 


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

## 概要

<!-- 変更の目的 もしくは 関連する Issue 番号 -->
- #50 カレンダーと月表示のずれを直す

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- OnResumeでヘッダーの月表示を現在の月にリセットするよう変更