### PR TITLE
[update] #59 予定追加するときの画面を編集

### DIFF
--- a/app/src/main/java/jp/ac/meijou/s231205036/android/schedulestrengthcalendar/AddScheduleActivity.java
+++ b/app/src/main/java/jp/ac/meijou/s231205036/android/schedulestrengthcalendar/AddScheduleActivity.java
@@ -8,6 +8,7 @@ import android.view.MotionEvent;
 import android.view.WindowManager;
 import android.widget.ArrayAdapter;
 import android.widget.EditText;
+import android.widget.NumberPicker;
 
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
@@ -37,14 +38,24 @@ public class AddScheduleActivity extends AppCompatActivity {
 
         // Spinner の設定
         String[] strongOptions = {"1","2", "3", "4", "5"};
-        var adapter = new ArrayAdapter<>(this, android.R.layout.simple_spinner_item, strongOptions);
-        adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
-        binding.spinnerNumber.setAdapter(adapter);
+        binding.spinnerNumber.setMinValue(0);
+        binding.spinnerNumber.setMaxValue(strongOptions.length - 1);
+        binding.spinnerNumber.setDisplayedValues(strongOptions);
+        binding.spinnerNumber.setWrapSelectorWheel(true);
+
+        //var adapter = new ArrayAdapter<>(this, android.R.layout.simple_spinner_item, strongOptions);
+        //adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        //binding.spinnerNumber.setAdapter(adapter);
 
         String[] repeatOptions = {"なし", "毎週", "隔週", "毎月"};
-        var repeatAdapter = new ArrayAdapter<>(this, android.R.layout.simple_spinner_item, repeatOptions);
-        repeatAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
-        binding.answer.setAdapter(repeatAdapter);
+        binding.answer.setMinValue(0);
+        binding.answer.setMaxValue(repeatOptions.length - 1);
+        binding.answer.setDisplayedValues(repeatOptions);
+        binding.answer.setWrapSelectorWheel(true);
+
+        //var repeatAdapter = new ArrayAdapter<>(this, android.R.layout.simple_spinner_item, repeatOptions);
+        //repeatAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        //binding.answer.setAdapter(repeatAdapter);
 
         binding.inputDate.setOnClickListener(view -> showDatePickerDialog());
         binding.TimeFirst.setOnClickListener(view -> showTimePickerDialog(binding.TimeFirst));
@@ -84,8 +95,9 @@ public class AddScheduleActivity extends AppCompatActivity {
             var startTime = binding.TimeFirst.getText().toString();
             var endTime = binding.TimeFinal.getText().toString();
             var memo = binding.memo.getText().toString();
-            var answer = binding.answer.getSelectedItem().toString();
-            var intensity = binding.spinnerNumber.getSelectedItem().toString();
+            var intensity = strongOptions[binding.spinnerNumber.getValue()];
+            var answer =  repeatOptions[binding.answer.getValue()];
+
 
             // Firestore に保存するデータを作成
             Map<String, Object> scheduleData = new HashMap<>();
@@ -141,7 +153,9 @@ public class AddScheduleActivity extends AppCompatActivity {
             this.selectedMonth = selectedMonth + 1;
             this.selectedDay = selectedDay;
 
-            binding.inputDate.setText(selectedYear + "/" + this.selectedMonth + "/" + this.selectedDay);
+            String dateText = selectedYear + "/" + this.selectedMonth + "/" + this.selectedDay;
+            binding.inputDate.setText(dateText);
+            binding.inputDate2.setText(dateText);  // input_date2に同じ日を表示
         }, year, month, day);
 
         datePickerDialog.show();

--- a/app/src/main/java/jp/ac/meijou/s231205036/android/schedulestrengthcalendar/EditScheduleActivity.java
+++ b/app/src/main/java/jp/ac/meijou/s231205036/android/schedulestrengthcalendar/EditScheduleActivity.java
@@ -48,14 +48,22 @@ public class EditScheduleActivity extends AppCompatActivity {
 
         // Spinner の設定
         String[] strongOptions = {"1","2", "3", "4", "5"};
-        var adapter = new ArrayAdapter<>(this, android.R.layout.simple_spinner_item, strongOptions);
-        adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
-        binding.spinnerNumber.setAdapter(adapter);
+        binding.spinnerNumber.setMinValue(0);
+        binding.spinnerNumber.setMaxValue(strongOptions.length - 1);
+        binding.spinnerNumber.setDisplayedValues(strongOptions);
+        binding.spinnerNumber.setWrapSelectorWheel(true);
+        //var adapter = new ArrayAdapter<>(this, android.R.layout.simple_spinner_item, strongOptions);
+        //adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        //binding.spinnerNumber.setAdapter(adapter);
 
         String[] repeatOptions = {"なし", "毎週", "隔週", "毎月"};
-        var repeatAdapter = new ArrayAdapter<>(this, android.R.layout.simple_spinner_item, repeatOptions);
-        repeatAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
-        binding.answer.setAdapter(repeatAdapter);
+        binding.answer.setMinValue(0);
+        binding.answer.setMaxValue(repeatOptions.length - 1);
+        binding.answer.setDisplayedValues(repeatOptions);
+        binding.answer.setWrapSelectorWheel(true);
+        //var repeatAdapter = new ArrayAdapter<>(this, android.R.layout.simple_spinner_item, repeatOptions);
+        //repeatAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        //binding.answer.setAdapter(repeatAdapter);
 
         binding.inputDate.setOnClickListener(view -> showDatePickerDialog());
         binding.TimeFirst.setOnClickListener(view -> showTimePickerDialog(binding.TimeFirst));
@@ -106,8 +114,15 @@ public class EditScheduleActivity extends AppCompatActivity {
                     binding.TimeFirst.setText(initialStartTime);
                     binding.TimeFinal.setText(initialEndTime);
                     binding.memo.setText(initialMemo);
-                    binding.spinnerNumber.setSelection(adapter.getPosition(initialIntensity));
-                    binding.answer.setSelection(repeatAdapter.getPosition(initialRepeat));
+
+                    binding.spinnerNumber.setValue(
+                            java.util.Arrays.asList(strongOptions).indexOf(initialIntensity)
+                    );
+
+                    binding.answer.setValue(
+                            java.util.Arrays.asList(repeatOptions).indexOf(initialRepeat)
+                    );
+
                     binding.inputDate.setText(selectedYear + "/" + (selectedMonth + 1) + "/" + selectedDay);
 
                     // 保存ボタンのクリックイベント
@@ -116,8 +131,8 @@ public class EditScheduleActivity extends AppCompatActivity {
                         var startTime = binding.TimeFirst.getText().toString();
                         var endTime = binding.TimeFinal.getText().toString();
                         var memo = binding.memo.getText().toString();
-                        var answer = binding.answer.getSelectedItem().toString();
-                        var intensity = binding.spinnerNumber.getSelectedItem().toString();
+                        var answer = strongOptions[binding.spinnerNumber.getValue()];
+                        var intensity = repeatOptions[binding.answer.getValue()];
 
                         // Firestore に保存するデータを作成
                         Map<String, Object> scheduleData = new HashMap<>();

--- a/app/src/main/res/layout/activity_add_schedule.xml
+++ b/app/src/main/res/layout/activity_add_schedule.xml
@@ -5,92 +5,89 @@
     android:id="@+id/main"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:backgroundTint="#FFFFFF"
+    android:backgroundTintMode="add"
     tools:context=".AddScheduleActivity">
-
-    <TextView
-        android:id="@+id/title"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="44dp"
-        android:layout_marginTop="84dp"
-        android:text="タイトル : "
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
 
     <EditText
         android:id="@+id/inputText"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="-12dp"
-        android:hint="ここに予定を入力"
-        android:inputType="text"
-        app:layout_constraintBottom_toBottomOf="@+id/title"
-        app:layout_constraintStart_toEndOf="@+id/title" />
-
-    <TextView
-        android:id="@+id/textView2"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="330dp"
+        android:layout_height="70dp"
         android:layout_marginStart="44dp"
-        android:layout_marginTop="36dp"
-        android:text="日付　 　: "
+        android:layout_marginTop="90dp"
+        android:hint="タイトル"
+        android:inputType="text"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/title" />
+        app:layout_constraintTop_toTopOf="parent" />
 
     <EditText
         android:id="@+id/input_date"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginBottom="-12dp"
-        android:focusable="false"
+        android:layout_marginStart="20dp"
         android:clickable="true"
+        android:focusable="false"
         android:hint="日付を選択"
-        app:layout_constraintBottom_toBottomOf="@+id/textView2"
-        app:layout_constraintStart_toEndOf="@+id/textView2" />
+        app:layout_constraintBottom_toBottomOf="@+id/first_time"
+        app:layout_constraintStart_toEndOf="@+id/first_time" />
 
     <TextView
         android:id="@+id/first_time"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="44dp"
-        android:layout_marginTop="36dp"
+        android:layout_marginTop="50dp"
         android:text="開始時刻 : "
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/textView2" />
+        app:layout_constraintTop_toBottomOf="@+id/inputText" />
 
     <EditText
         android:id="@+id/TimeFirst"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginEnd="40dp"
         android:layout_marginBottom="-12dp"
-        android:hint="開始時刻の入力"
-        android:focusable="false"
         android:clickable="true"
+        android:focusable="false"
+        android:hint="開始時刻の入力"
         android:inputType="time"
         app:layout_constraintBottom_toBottomOf="@+id/first_time"
-        app:layout_constraintStart_toEndOf="@+id/first_time" />
+        app:layout_constraintEnd_toEndOf="parent" />
 
     <TextView
         android:id="@+id/final_time"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="44dp"
-        android:layout_marginTop="44dp"
+        android:layout_marginTop="50dp"
         android:text="終了時刻 : "
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/first_time" />
 
     <EditText
-        android:id="@+id/TimeFinal"
+        android:id="@+id/input_date2"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginBottom="-12dp"
-        android:hint="終了時刻の入力"
+        android:layout_marginStart="20dp"
         android:focusable="false"
-        android:clickable="true"
-        android:inputType="time"
+        android:hint="日付を選択"
         app:layout_constraintBottom_toBottomOf="@+id/final_time"
         app:layout_constraintStart_toEndOf="@+id/final_time" />
+
+    <EditText
+        android:id="@+id/TimeFinal"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="40dp"
+        android:layout_marginBottom="-12dp"
+        android:clickable="true"
+        android:focusable="false"
+        android:hint="終了時刻の入力"
+        android:inputType="time"
+        app:layout_constraintBottom_toBottomOf="@+id/final_time"
+        app:layout_constraintEnd_toEndOf="parent" />
 
 
     <TextView
@@ -98,76 +95,88 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="44dp"
-        android:layout_marginTop="44dp"
+        android:layout_marginTop="100dp"
         android:text="強度(1-5) : "
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/final_time" />
 
-    <Spinner
+    <NumberPicker
         android:id="@+id/spinnerNumber"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        app:layout_constraintBottom_toBottomOf="@+id/strong"
-        app:layout_constraintStart_toEndOf="@+id/strong" />
+        android:layout_width="100dp"
+        android:layout_height="80dp"
+        android:layout_marginBottom="-25dp"
+        android:layout_marginStart="20dp"
+        app:layout_constraintStart_toEndOf="@+id/strong"
+        app:layout_constraintBottom_toBottomOf="@+id/strong" />
 
     <TextView
         android:id="@+id/text"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="44dp"
-        android:layout_marginTop="44dp"
+        android:layout_marginTop="90dp"
         android:text="メモ : "
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/strong" />
+        app:layout_constraintTop_toBottomOf="@id/repeat"/>
+
 
     <EditText
         android:id="@+id/memo"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="44dp"
+        android:layout_width="294dp"
+        android:layout_height="100dp"
+        android:layout_marginStart="60dp"
         android:hint="メモの内容"
         android:inputType="textMultiLine"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/text" />
-
 
     <TextView
         android:id="@+id/repeat"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="44dp"
-        android:layout_marginTop="44dp"
+        android:layout_marginTop="100dp"
         android:text="繰り返し : "
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/memo" />
+        app:layout_constraintTop_toBottomOf="@id/strong"
+        />
 
-
-    <Spinner
+    <NumberPicker
         android:id="@+id/answer"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
+        android:layout_width="100dp"
+        android:layout_height="80dp"
+        android:layout_marginBottom="-25dp"
+        android:layout_marginStart="20dp"
         app:layout_constraintStart_toEndOf="@id/repeat"
-        app:layout_constraintTop_toTopOf="@id/repeat" />
+        app:layout_constraintBottom_toBottomOf="@id/repeat" />
 
     <Button
         android:id="@+id/save"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="120dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="24dp"
+        android:backgroundTint="#00FFFFFF"
         android:text="保存"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/back"
-        app:layout_constraintEnd_toEndOf="parent" />
+        android:textColor="#C62196F3"
+        android:textSize="20sp"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <Button
         android:id="@+id/back"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="120dp"
+        android:layout_marginStart="24dp"
+        android:layout_marginTop="16dp"
+        android:backgroundTint="#00FFFFFF"
         android:text="戻る"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/save"
-        app:layout_constraintStart_toStartOf="parent" />
+        android:textColor="#C62196F3"
+        android:textSize="20sp"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->
## 概要
<!-- 変更の目的 もしくは 関連する Issue 番号 -->

- 予定通過する沖の画面を編集

## 変更内容
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

- 追加ボタンの位置変更
- 日付の位置変更(時刻の隣に日付の欄を移動、終了時刻の隣にある日付の欄は自動入力される)
- 強度と繰り返しのドロップダウンをドラムロールに変更

## 影響範囲
<!-- この関数を変更したのでこの機能にも影響がある、など -->

- AddScheduleActivityのintensityとanswerの値のコードを変更
- EditScheduleActivityのinitialIntensityとinitialRepeatに値をセットするコードを変更

## 動作要件
<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->

- 特になし
