### PR TITLE
[change] #61 SQLiteへの移行（データベース大幅改変）

### DIFF
--- a/app/src/main/java/io/github/shun/osugi/busible/dao/DateDao.java
+++ b/app/src/main/java/io/github/shun/osugi/busible/dao/DateDao.java
@@ -31,6 +31,10 @@ public interface DateDao {
     @Delete
     void delete(Date date);
 
+    // idからDateを取得するメソッド
+    @Query("SELECT * FROM date WHERE id = :id LIMIT 1")
+    LiveData<Date> getDateById(int id);
+
     // 非同期で全ての日付を取得するメソッド
     @Query("SELECT * FROM date")
     LiveData<List<Date>> getAllDates();
@@ -39,6 +43,6 @@ public interface DateDao {
     @Query("SELECT * FROM date WHERE year = :year AND month = :month AND day = :day")
     LiveData<Date> getDateBySpecificDay(int year, int month, int day);
 
-    @Query("SELECT * FROM date WHERE year = :year AND month = :month AND day = :day")
-    Date getDate(int year, int month, int day);
+    // @Query("SELECT * FROM date WHERE year = :year AND month = :month AND day = :day")
+    // Date getDate(int year, int month, int day);
 }

--- a/app/src/main/java/io/github/shun/osugi/busible/dao/ScheduleDao.java
+++ b/app/src/main/java/io/github/shun/osugi/busible/dao/ScheduleDao.java
@@ -25,9 +25,13 @@ public interface ScheduleDao {
     @Delete
     void delete(Schedule schedule);
 
-    // IDでスケジュールを取得
+    // idでスケジュールを取得
     @Query("SELECT * FROM schedule WHERE id = :id")
     LiveData<Schedule> getScheduleById(int id);
+
+    // dateIdでスケジュールを取得
+    @Query("SELECT * FROM schedule WHERE Dateid = :dateId")
+    LiveData<List<Schedule>> getSchedulesByDateId(int dateId);
 
     // 全スケジュールを取得
     @Query("SELECT * FROM schedule")

--- a/app/src/main/java/io/github/shun/osugi/busible/entity/Schedule.java
+++ b/app/src/main/java/io/github/shun/osugi/busible/entity/Schedule.java
@@ -6,11 +6,15 @@ import androidx.room.ForeignKey;
 import androidx.room.PrimaryKey;
 
 
-@Entity(tableName = "schedule")
-public class Schedule {
+@Entity(tableName = "schedule",
+        foreignKeys = @ForeignKey(entity = Date.class,
+                parentColumns = "id",
+                childColumns = "dateId",
+                onDelete = ForeignKey.CASCADE))public class Schedule {
     @PrimaryKey(autoGenerate = true) // 主キーを自動生成
-    private int id;
+    private int id; // 一意のID
 
+    private int dateId; // 外部キー
     private String title; // 予定のタイトル
     private String memo; // 詳細な説明
     private int strong; //強度
@@ -28,6 +32,14 @@ public class Schedule {
 
     public void setId(int id) {
         this.id = id;
+    }
+
+    public int getDateId() {
+        return dateId;
+    }
+
+    public void setDateId(int dateId) {
+        this.dateId = dateId;
     }
 
     public int getStrong() { // ここで強度の getter を追加

--- a/app/src/main/java/io/github/shun/osugi/busible/repository/ScheduleRepository.java
+++ b/app/src/main/java/io/github/shun/osugi/busible/repository/ScheduleRepository.java
@@ -1,0 +1,30 @@
+package io.github.shun.osugi.busible.repository;
+
+import android.app.Application;
+import androidx.lifecycle.LiveData;
+import java.util.List;
+
+import io.github.shun.osugi.busible.dao.ScheduleDao;
+import io.github.shun.osugi.busible.database.AppDatabase;
+import io.github.shun.osugi.busible.entity.Schedule;
+
+public class ScheduleRepository {
+
+    public ScheduleDao scheduleDao; // DAOへの参照
+
+    // コンストラクタでデータベースのインスタンスを取得
+    public ScheduleRepository(Application application) {
+        AppDatabase db = AppDatabase.getDatabase(application); // AppDatabaseを使ってDBインスタンスを取得
+        scheduleDao = db.scheduleDao(); // DAOを取得
+    }
+
+    // 日付IDに基づいてスケジュールを取得
+    public LiveData<List<Schedule>> getSchedulesByDateId(int dateId) {
+        return scheduleDao.getSchedulesByDateId(dateId); // DAOメソッドを呼び出し
+    }
+
+    // IDでScheduleを取得
+    public LiveData<Schedule> getScheduleById(int id) {
+        return scheduleDao.getScheduleById(id);
+    }
+}

--- a/app/src/main/java/io/github/shun/osugi/busible/ui/Activity.java
+++ b/app/src/main/java/io/github/shun/osugi/busible/ui/Activity.java
@@ -33,7 +33,7 @@ public class Activity extends AppCompatActivity {
     private void testDatabaseOperations() {
         // 新しいスケジュールを作成
         Schedule newSchedule = new Schedule();
-        newSchedule.setId(1);
+        newSchedule.setDateId(1);
         newSchedule.setTitle("Test Schedule");
         newSchedule.setStartTime("10:00");
         newSchedule.setEndTime("11:00");

--- a/app/src/main/java/io/github/shun/osugi/busible/viewmodel/DateViewModel.java
+++ b/app/src/main/java/io/github/shun/osugi/busible/viewmodel/DateViewModel.java
@@ -34,6 +34,11 @@ public class DateViewModel extends AndroidViewModel {
         return dateDao.getDateBySpecificDay(year, month, day);
     }
 
+    // IDで日付を取得
+    public LiveData<Date> getDateById(int id) {
+        return dateDao.getDateById(id);
+    }
+
     // 日付を挿入
     public void insert(Date date) {
         new Thread(() -> {

--- a/app/src/main/java/io/github/shun/osugi/busible/viewmodel/ScheduleViewModel.java
+++ b/app/src/main/java/io/github/shun/osugi/busible/viewmodel/ScheduleViewModel.java
@@ -10,6 +10,7 @@ import java.util.List;
 import io.github.shun.osugi.busible.dao.ScheduleDao;
 import io.github.shun.osugi.busible.database.AppDatabase;
 import io.github.shun.osugi.busible.entity.Schedule;
+import io.github.shun.osugi.busible.repository.ScheduleRepository;
 
 public class ScheduleViewModel extends AndroidViewModel {
     private ScheduleDao scheduleDao;
@@ -18,12 +19,14 @@ public class ScheduleViewModel extends AndroidViewModel {
     private LiveData<List<Schedule>> schedulesByRepeat;
     private LiveData<List<Schedule>> schedulesByStartTime;
     private LiveData<List<Schedule>> schedulesByEndTime;
+    private ScheduleRepository repository;
 
     public ScheduleViewModel(Application application) {
         super(application);
         AppDatabase db = AppDatabase.getDatabase(application);
         scheduleDao = db.scheduleDao();
         allSchedules = scheduleDao.getAllSchedules();
+        repository = new ScheduleRepository(application);
     }
 
     // スケジュールの挿入
@@ -41,9 +44,14 @@ public class ScheduleViewModel extends AndroidViewModel {
         new Thread(() -> scheduleDao.delete(schedule)).start();
     }
 
-    // IDでスケジュールを取得
+    // idでスケジュールを取得
     public LiveData<Schedule> getScheduleById(int id) {
-        return scheduleDao.getScheduleById(id);
+        return repository.scheduleDao.getScheduleById(id);
+    }
+
+    // dateIdでスケジュールを取得
+    public LiveData<List<Schedule>> getSchedulesByDateId(int id) {
+        return repository.scheduleDao.getSchedulesByDateId(id);
     }
 
     // 全スケジュールを取得


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

## 概要

<!-- 変更の目的 もしくは 関連する Issue 番号 -->
- #61 SQLiteへの移行

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- Scheduleエンティティに外部キーdateIdを導入、一つのDateに複数のScheduleを紐づけ
- Date,ScheduleともにDao,ViewModelに複数の関数を追加
- CalendarActivity,AddScheduleActivity,EditScheduleActivityをSQLiteに対応

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->
- DaoやViewModelに変更を加えているため、各所影響が出ることが予想される。

## 動作要件

<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
- x

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
- EditScheduleActivityについて、データ更新は現状うまくいっていない。
- AddScheduleActivityと比べて、未実装部分が見られたため、EditScheduleActivityにも同じように記述しておいたが、それが原因かは不明。
- Firebase等の元々あった不要なプログラムは一旦全てコメントアウトで残している。