### PR TITLE
[fix] #113 DateViewModel内のinsert処理において、非同期処理終了後に日付のIDを返すよう変更

### DIFF
--- a/app/src/main/java/io/github/shun/osugi/busible/ui/AddScheduleActivity.java
+++ b/app/src/main/java/io/github/shun/osugi/busible/ui/AddScheduleActivity.java
@@ -49,7 +49,6 @@ public class AddScheduleActivity extends AppCompatActivity {
         // 初期値設定
         initializeFields();
 
-
         ScheduleViewModel scheduleViewModel = new ViewModelProvider(this).get(ScheduleViewModel.class);
         DateViewModel dateViewModel = new ViewModelProvider(this).get(DateViewModel.class);
 
@@ -137,7 +136,9 @@ public class AddScheduleActivity extends AppCompatActivity {
             String memo = binding.memo.getText().toString();
             String strong = strongOptions[binding.spinnerNumber.getValue()];
             String repeatOption = repeatOptions[binding.answer.getValue()];
+
             LiveData<Date> dateLiveData = dateViewModel.getDateBySpecificDay(selectedYear, selectedMonth, selectedDay);
+
             dateLiveData.observe(this, date -> {
                 int dateId = getOrMakeDateId(dateViewModel, date);
                 saveSchedule(scheduleViewModel, dateId, title, memo, strong, startTime, endTime, selectedColor, repeatOption);
@@ -241,9 +242,9 @@ public class AddScheduleActivity extends AppCompatActivity {
             newdate.setYear(selectedYear);
             newdate.setMonth(selectedMonth);
             newdate.setDay(selectedDay);
-            dateViewModel.insert(newdate);
+            long newId = dateViewModel.insert(newdate);
 
-            return newdate.getId();
+            return (int)newId;
         }
     }
 


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

## 概要

<!-- 変更の目的 もしくは 関連する Issue 番号 -->
- #113 AddScheduleActivity内のgetOrMake関数でInsert処理が非同期に行われていたことにより、dateIDの取得に失敗していた件についての修正

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- DateViewModel内のInsert処理に変更を加え、非同期でdateID取得するのを待った上で、IDを返すようにした。
- getOrMake関数内では、Insert処理の戻り値をそのまま返すようにしている。

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->
- DateViewModel内のInsert処理の戻り値を変更しているため、影響が出る可能性があるが、今のところエラーは見られない。

## 動作要件

<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
- x

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
- しばしば、予定が２回重複して追加されることがあるが、追加側のバグか描画側のバグかは不明。ただ、カレンダー描画において、前月のマスに今月の予定が反映されたり強度の反映がうまくいかないことがあったため（どちらも再描画すると改善）、描画処理の見直しは必要と思われる。