### PR TITLE
[fix] #115 予定の変更が適用されるよう修正

### DIFF
--- a/app/src/main/java/io/github/shun/osugi/busible/ui/CalendarActivity.java
+++ b/app/src/main/java/io/github/shun/osugi/busible/ui/CalendarActivity.java
@@ -588,6 +588,7 @@ public class CalendarActivity extends AppCompatActivity {
                             buttonContainer.addView(editButton);
 
                             editButton.setOnClickListener(edit -> {
+                                bottomSheetDialog.dismiss();
                                 // Intent を作成して EditSchedule へ遷移
                                 Intent intent = new Intent(CalendarActivity.this, EditScheduleActivity.class);
                                 intent.putExtra("scheduleId", schedule.getId());


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

## 概要

<!-- 変更の目的 もしくは 関連する Issue 番号 -->
- #115 #58 

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- AddScheduleActivityを基に一からEditScheduleActivityを作成
- EditScheduleActivityはAddScheduleActivityに倣い、initializeFields関数により、登録された値を各フィールドに設定している
- 変更適用時には、元の予定を削除し、変更後の予定を新たな予定として登録している
- ついでにCalendarActivityからEditScheduleActivityに遷移時にダイアログを消すように変更

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->
- x

## 動作要件

<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
- x

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
- x