### PR TITLE
[change] #115 予定変更時の操作を変更

### DIFF
--- a/app/src/main/java/io/github/shun/osugi/busible/ui/EditScheduleActivity.java
+++ b/app/src/main/java/io/github/shun/osugi/busible/ui/EditScheduleActivity.java
@@ -147,8 +147,7 @@ public class EditScheduleActivity extends AppCompatActivity {
 
                     dateLiveData.observe(this, date -> {
                         int dateId = getOrMakeDateId(dateViewModel, date);
-                        saveSchedule(scheduleViewModel, dateId, title, memo, strong, startTime, endTime, selectedColor, repeatOption);
-                        scheduleViewModel.delete(schedule);
+                        updateSchedule(scheduleViewModel, schedule, dateId, title, memo, strong, startTime, endTime, selectedColor, repeatOption);
                         finish();  // 画面を閉じて前の画面に戻る
                     });
                 });
@@ -159,10 +158,9 @@ public class EditScheduleActivity extends AppCompatActivity {
         });
     }
 
-    // データベースに保存
-    private void saveSchedule(ScheduleViewModel scheduleViewModel,int dateId, String title, String memo, String strong,
+    // データベースを更新
+    private void updateSchedule(ScheduleViewModel scheduleViewModel, Schedule schedule,int dateId, String title, String memo, String strong,
                               String startTime, String endTime, String selectedColor, String repeatOption) {
-        Schedule schedule = new Schedule();
         schedule.setDateId(dateId);
         schedule.setTitle(title);
         schedule.setMemo(memo);
@@ -172,8 +170,7 @@ public class EditScheduleActivity extends AppCompatActivity {
         schedule.setColor(selectedColor);
         schedule.setRepeat(repeatOption);
 
-        // スケジュールを非同期で保存
-        scheduleViewModel.insert(schedule);
+        scheduleViewModel.update(schedule);
         Log.d(TAG, "Schedule By ID: " + schedule.getTitle());
     }
 


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

## 概要

<!-- 変更の目的 もしくは 関連する Issue 番号 -->
- #115 

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- 予定編集時に、元のデータを削除し新たなデータを保存していたのを、元のデータを更新するように変更
- 保存時のデータ削除を削除
- EditScheduleActivity内のsaveSchedule関数をupdateSchedule関数とし、関数内のinsert処理をupdate処理に変更

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->
- 

## 動作要件

<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
- x

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
- x