### PR TITLE
[add] #122 予定追加画面で開始時間よりも終了時間が早くても保存できてしまうのを解消

### DIFF
--- a/app/src/main/java/io/github/shun/osugi/busible/ui/EditScheduleActivity.java
+++ b/app/src/main/java/io/github/shun/osugi/busible/ui/EditScheduleActivity.java
@@ -21,6 +21,7 @@ import androidx.lifecycle.ViewModelProvider;
 
 import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Locale;
 
 import io.github.shun.osugi.busible.R;
 import io.github.shun.osugi.busible.databinding.ActivityAddScheduleBinding;
@@ -55,6 +56,7 @@ public class EditScheduleActivity extends AppCompatActivity {
         Intent intent = getIntent();
         int scheduleId = intent.getIntExtra("scheduleId", -1);
         scheduleViewModel.getScheduleById(scheduleId).observe(this, schedule -> {
+
             if(schedule != null) {
                 // Button名を変更
                 binding.incident.setText("イベントを編集");
@@ -115,26 +117,17 @@ public class EditScheduleActivity extends AppCompatActivity {
                 // 入力されたタイトルに応じて保存ボタンを有効化
                 binding.inputText.addTextChangedListener(new TextWatcher() {
                     @Override
-                    public void beforeTextChanged(CharSequence charSequence, int start, int count, int after) {}
+                    public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
 
                     @Override
-                    public void onTextChanged(CharSequence charSequence, int start, int before, int after) {
-                        String title = binding.inputText.getText().toString();
-                        // タイトルが空でない場合に保存ボタンを有効化
-                        if (!title.isEmpty()) {
-                            // タイトルが入力されている場合、ボタンの色を元に戻す
-                            binding.save.setTextColor(Color.parseColor("#034AFF")); // 元の色に変更
-                            binding.save.setEnabled(true); // ボタンを有効にする
-                        } else {
-                            // タイトルが空の場合、ボタンを無効にして色を薄くする
-                            binding.save.setTextColor(Color.parseColor("#A0A0A0")); // 薄い色に変更
-                            binding.save.setEnabled(false); // ボタンを無効にする
-                        }
+                    public void onTextChanged(CharSequence s, int start, int before, int count) {
+                        checkSaveButtonState();
                     }
 
                     @Override
-                    public void afterTextChanged(Editable editable) {}
+                    public void afterTextChanged(Editable s) {}
                 });
+
 
                 // 保存ボタンのクリックイベント
                 binding.save.setOnClickListener(view -> {
@@ -198,12 +191,9 @@ public class EditScheduleActivity extends AppCompatActivity {
 
     // 時間ピッカー
     private void showTimePickerDialog(final EditText editText) {
-        // 現在のテキストフィールドに表示されている時刻を取得
         String currentText = editText.getText().toString();
-        int hour = 9; // デフォルト値
-        int minute = 0;
+        int hour = 9, minute = 0;
 
-        // 時刻フォーマットが正しい場合、初期値を解析
         if (currentText.matches("\\d{2}:\\d{2}")) {
             String[] parts = currentText.split(":");
             hour = Integer.parseInt(parts[0]);
@@ -212,11 +202,51 @@ public class EditScheduleActivity extends AppCompatActivity {
 
         TimePickerDialog timePickerDialog = new TimePickerDialog(this,
                 (view, selectedHour, selectedMinute) -> {
-                    String time = String.format("%2d:%02d", selectedHour, selectedMinute);
+                    String time = String.format(Locale.getDefault(), "%02d:%02d", selectedHour, selectedMinute);
                     editText.setText(time);
+                    checkSaveButtonState();
                 }, hour, minute, true);
 
         timePickerDialog.show();
+    }
+
+    private void checkSaveButtonState() {
+        String title = binding.inputText.getText().toString();
+        String startTime = binding.TimeFirst.getText().toString();
+        String endTime = binding.TimeFinal.getText().toString();
+
+        boolean isTitleNotEmpty = !title.isEmpty();
+        boolean isValidTime = isValidTimeRange(startTime, endTime);
+
+        if (isTitleNotEmpty && isValidTime) {
+            binding.save.setEnabled(true);
+            binding.save.setTextColor(Color.parseColor("#034AFF")); // 有効時の色
+
+        } else {
+            binding.save.setEnabled(false);
+            binding.save.setTextColor(Color.parseColor("#A0A0A0")); // 無効時の色
+
+            if (!isValidTime) {
+                Toast.makeText(binding.inputText.getContext(), "終了時間は開始時間よりも\n後にしてください", Toast.LENGTH_SHORT).show();
+            }
+        }
+    }
+
+    //タイトルと時間の両方をチェック
+    private boolean isValidTimeRange(String startTime, String endTime) {
+        if (!startTime.matches("\\d{2}:\\d{2}") || !endTime.matches("\\d{2}:\\d{2}")) {
+            return false;
+        }
+
+        String[] startParts = startTime.split(":");
+        String[] endParts = endTime.split(":");
+
+        int startHour = Integer.parseInt(startParts[0]);
+        int startMinute = Integer.parseInt(startParts[1]);
+        int endHour = Integer.parseInt(endParts[0]);
+        int endMinute = Integer.parseInt(endParts[1]);
+
+        return (endHour > startHour) || (endHour == startHour && endMinute > startMinute);
     }
 
     // フィールドを初期化するメソッド


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

## 概要

<!-- 変更の目的 もしくは 関連する Issue 番号 -->
- 122

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- 予定追加画面で開始時間よりも終了時間が早くても保存できてしまうのを解消するために、開始時間よりも終了時間が早いときには保存ボタンを押せなくし、メッセージを表示させるようにした。

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->
- 特になし

## 動作要件

<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
- 特になし
