### PR TITLE
[fix] #123 予定追加画面で予定日を変更したら,デフォルトで変更したその日が選択されているようにする

### DIFF
--- a/app/src/main/java/io/github/shun/osugi/busible/ui/EditScheduleActivity.java
+++ b/app/src/main/java/io/github/shun/osugi/busible/ui/EditScheduleActivity.java
@@ -171,11 +171,12 @@ public class EditScheduleActivity extends AppCompatActivity {
 
     // 日付ピッカー
     private void showDatePickerDialog() {
-        Calendar calendar = Calendar.getInstance();
-        int year = calendar.get(Calendar.YEAR);
-        int month = calendar.get(Calendar.MONTH);
-        int day = calendar.get(Calendar.DAY_OF_MONTH);
+        // 現在選択されている日付を取得（初期値として今日の日付）
+        int year = this.selectedYear != 0 ? this.selectedYear : Calendar.getInstance().get(Calendar.YEAR);
+        int month = this.selectedMonth != 0 ? this.selectedMonth : Calendar.getInstance().get(Calendar.MONTH);
+        int day = this.selectedDay != 0 ? this.selectedDay : Calendar.getInstance().get(Calendar.DAY_OF_MONTH);
 
+        // DatePickerDialog の表示
         DatePickerDialog datePickerDialog = new DatePickerDialog(this, (view, selectedYear, selectedMonth, selectedDay) -> {
             this.selectedYear = selectedYear;
             this.selectedMonth = selectedMonth;
@@ -188,6 +189,7 @@ public class EditScheduleActivity extends AppCompatActivity {
 
         datePickerDialog.show();
     }
+
 
     // 時間ピッカー
     private void showTimePickerDialog(final EditText editText) {


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

## 概要

<!-- 変更の目的 もしくは 関連する Issue 番号 -->
- 123

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- 予定追加画面で予定日を変更したら、デフォルトで変更したその日が選択されているようにした。

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->
- 特になし

## 動作要件

<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
- 特になし
