### PR TITLE
[add] #122 予定追加画面で状況に応じたメッセージを表示させる

### DIFF
--- a/app/src/main/java/io/github/shun/osugi/busible/ui/EditScheduleActivity.java
+++ b/app/src/main/java/io/github/shun/osugi/busible/ui/EditScheduleActivity.java
@@ -130,21 +130,36 @@ public class EditScheduleActivity extends AppCompatActivity {
 
 
                 // 保存ボタンのクリックイベント
-                binding.save.setOnClickListener(view -> {
+                binding.save.setOnClickListener(v -> {
                     String title = binding.inputText.getText().toString();
                     String startTime = binding.TimeFirst.getText().toString();
                     String endTime = binding.TimeFinal.getText().toString();
-                    String memo = binding.memo.getText().toString();
-                    String strong = strongOptions[binding.spinnerNumber.getValue()];
-                    String repeatOption = repeatOptions[binding.answer.getValue()];
 
-                    LiveData<Date> dateLiveData = dateViewModel.getDateBySpecificDay(selectedYear, selectedMonth, selectedDay);
+                    boolean isTitleNotEmpty = !title.isEmpty();
+                    boolean isValidTime = isValidTimeRange(startTime, endTime);
 
-                    dateLiveData.observe(this, date -> {
-                        int dateId = getOrMakeDateId(dateViewModel, date);
-                        updateSchedule(scheduleViewModel, schedule, dateId, title, memo, strong, startTime, endTime, selectedColor, repeatOption);
-                        finish();  // 画面を閉じて前の画面に戻る
-                    });
+                    if (isTitleNotEmpty && isValidTime) {
+                        // **条件を満たしている場合のみデータを保存**
+                        String memo = binding.memo.getText().toString();
+                        String strong = strongOptions[binding.spinnerNumber.getValue()];
+                        String repeatOption = repeatOptions[binding.answer.getValue()];
+
+                        LiveData<Date> dateLiveData = dateViewModel.getDateBySpecificDay(selectedYear, selectedMonth, selectedDay);
+                        dateLiveData.observe(this, date -> {
+                            int dateId = getOrMakeDateId(dateViewModel, date);
+                            updateSchedule(scheduleViewModel, schedule, dateId, title, memo, strong, startTime, endTime, selectedColor, repeatOption);
+                            finish(); // 画面を閉じる
+                        });
+                    } else {
+                        // **条件を満たしていない場合、データは保存せずエラーメッセージを表示**
+                        if (!isTitleNotEmpty && !isValidTime) {
+                            Toast.makeText(binding.save.getContext(), "タイトルを入力し, 開始時間は\n終了時間より先にしてください", Toast.LENGTH_SHORT).show();
+                        } else if (!isTitleNotEmpty) {
+                            Toast.makeText(binding.save.getContext(), "タイトルを入力してください", Toast.LENGTH_SHORT).show();
+                        } else if (!isValidTime) {
+                            Toast.makeText(binding.save.getContext(), "開始時間は終了時間より\n先にしてください", Toast.LENGTH_SHORT).show();
+                        }
+                    }
                 });
 
             }else{
@@ -221,16 +236,11 @@ public class EditScheduleActivity extends AppCompatActivity {
         boolean isValidTime = isValidTimeRange(startTime, endTime);
 
         if (isTitleNotEmpty && isValidTime) {
-            binding.save.setEnabled(true);
-            binding.save.setTextColor(Color.parseColor("#034AFF")); // 有効時の色
-
+            // 条件を満たす場合（タイトルがあり、開始時間 < 終了時間）
+            binding.save.setTextColor(Color.parseColor("#034AFF")); // 青色
         } else {
-            binding.save.setEnabled(false);
-            binding.save.setTextColor(Color.parseColor("#A0A0A0")); // 無効時の色
-
-            if (!isValidTime) {
-                Toast.makeText(binding.inputText.getContext(), "終了時間は開始時間よりも\n後にしてください", Toast.LENGTH_SHORT).show();
-            }
+            // 条件を満たさない場合（タイトルがない or 開始時間 >= 終了時間）
+            binding.save.setTextColor(Color.parseColor("#A0A0A0")); // 灰色
         }
     }
 


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

## 概要

<!-- 変更の目的 もしくは 関連する Issue 番号 -->
- 122

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- 保存ボタンをおすことで, 
- タイトルが入力されていない時→タイトルを入力してください
- 開始時間より終了時間の方が早い時→開始時間は終了時間よりも前にしてください
- タイトルの入力なしかつ 開始時間より終了時間の方が早い時→タイトルを入力し, 正確な時刻を選択して下さい
- とメッセージを出すように修正

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->
- 特になし

## 動作要件

<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
- 特になし
