### PR TITLE
[fix] #127 予定を削除した後にリロードを行わないと背景の色の反映が行われない問題を解決

### DIFF
--- a/app/src/main/java/io/github/shun/osugi/busible/ui/CalendarActivity.java
+++ b/app/src/main/java/io/github/shun/osugi/busible/ui/CalendarActivity.java
@@ -604,8 +604,12 @@ public class CalendarActivity extends AppCompatActivity {
                                         .setPositiveButton("削除", (dialog2, which) -> {
                                             // 削除し、ダイアログを閉じる
                                             scheduleViewModel.delete(schedule);
+
+                                            // ダイアログを閉じる
                                             bottomSheetDialog.dismiss();
-                                            refreshCalendarData(year, month+1);
+
+                                            // UIを即時更新
+                                            refreshCalendarData(year, month);
                                         })
                                         .setNegativeButton("キャンセル", (dialog2, which) -> {
                                             // ダイアログを閉じる


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

## 概要

<!-- 変更の目的 もしくは 関連する Issue 番号 -->
- 127

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- 予定を削除した後にリロードを行わないと背景の色の反映が行われない問題を解決

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->
- 特になし

## 動作要件

<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
- 特になし

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
- 反映の速度が遅く、一瞬変な挙動あり