### PR TITLE
[fix] #145 予定追加、編集、削除時の挙動を変更

### DIFF
--- a/app/src/main/java/io/github/shun/osugi/busible/ui/AddScheduleActivity.java
+++ b/app/src/main/java/io/github/shun/osugi/busible/ui/AddScheduleActivity.java
@@ -3,6 +3,7 @@ package io.github.shun.osugi.busible.ui;
 import android.annotation.SuppressLint;
 import android.app.DatePickerDialog;
 import android.app.TimePickerDialog;
+import android.content.Intent;
 import android.graphics.Color;
 import android.os.Bundle;
 import android.text.Editable;
@@ -139,6 +140,12 @@ public class AddScheduleActivity extends AppCompatActivity {
                 dateLiveData.observe(this, date -> {
                     int dateId = getOrMakeDateId(dateViewModel, date);
                     saveSchedule(scheduleViewModel, dateId, title, memo, strong, startTime, endTime, selectedColor, repeatOption);
+                    dateLiveData.removeObservers(this);
+                    // 保存処理の最後にカレンダー更新用のデータを渡す
+                    Intent resultIntent = new Intent(AddScheduleActivity.this, CalendarActivity.class);
+                    resultIntent.putExtra("selectedYear", selectedYear);
+                    resultIntent.putExtra("selectedMonth", selectedMonth);
+                    startActivity(resultIntent);
                     finish(); // 画面を閉じる
                 });
             } else {

--- a/app/src/main/java/io/github/shun/osugi/busible/ui/CalendarActivity.java
+++ b/app/src/main/java/io/github/shun/osugi/busible/ui/CalendarActivity.java
@@ -37,6 +37,7 @@ import androidx.core.graphics.Insets;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
 import androidx.lifecycle.LiveData;
+import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProvider;
 
 import android.util.Log;
@@ -76,11 +77,22 @@ public class CalendarActivity extends AppCompatActivity {
         dateViewModel = new ViewModelProvider(this).get(DateViewModel.class);
         scheduleViewModel = new ViewModelProvider(this).get(ScheduleViewModel.class);
 
-        // 現在の年と月を取得して headerText に設定
-        Calendar calendar = Calendar.getInstance();
-        updateHeaderText(calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH));
+        Calendar calendar = Calendar.getInstance();  // 現在のカレンダーを取得
 
-        setHolidays(calendar.get(Calendar.YEAR));
+        // Intentの取得
+        Intent resultIntent = getIntent();
+        int year = resultIntent.getIntExtra("selectedYear", -1);
+        int month = resultIntent.getIntExtra("selectedMonth", -1);
+
+        if (year == -1 || month == -1) {
+            year = calendar.get(Calendar.YEAR);
+            month = calendar.get(Calendar.MONTH);
+        }else{
+            calendar.set(Calendar.YEAR, year);
+            calendar.set(Calendar.MONTH, month);
+        }
+
+        setHolidays(year);
 
         // 前月ボタンのクリックリスナーを設定
         binding.lastMonthButton.setOnClickListener(view -> {
@@ -148,7 +160,6 @@ public class CalendarActivity extends AppCompatActivity {
                 }
                 // ログに出力
                 Log.d("HolidayApiFetcher", "Received holiday data: " + holidayData.toString());
-
             }
 
             @Override
@@ -170,11 +181,21 @@ public class CalendarActivity extends AppCompatActivity {
     @Override
     protected void onResume() {
         super.onResume();
-        Calendar calendar = Calendar.getInstance();  // 現在のカレンダーを取得
-        TableLayout tableLayout = findViewById(R.id.calender);
 
-        // 現在の年と月を取得して headerText に設定
-        updateHeaderText(calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH));
+        Intent resultIntent = getIntent();
+        int year = resultIntent.getIntExtra("selectedYear", -1);
+        int month = resultIntent.getIntExtra("selectedMonth", -1);
+
+        if (year == -1 || month == -1) {
+            Calendar calendar = Calendar.getInstance();  // 現在のカレンダーを取得
+            year = calendar.get(Calendar.YEAR);
+            month = calendar.get(Calendar.MONTH);
+        }
+
+        Log.d(TAG, "onResume: " + year + "/" + (month + 1));
+
+        TableLayout tableLayout = findViewById(R.id.calender);
+        updateHeaderText(year, month);
 
         // 重複してカレンダーが生成されないようにビューをクリア
         tableLayout.removeAllViews();
@@ -217,7 +238,7 @@ public class CalendarActivity extends AppCompatActivity {
             tableLayout.addView(tableRow);
         }
         // データの再描画
-        refreshCalendarData(calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH));
+        refreshCalendarData(year, month);
     }
 
     private void refreshCalendarData(int year, int month) {
@@ -227,10 +248,13 @@ public class CalendarActivity extends AppCompatActivity {
         binding.lastMonthButton.setEnabled(false);        // ボタン無効化
         binding.nextMonthButton.setEnabled(false);
 
+        Log.d(TAG, "refresh calendar");
+
         // カレンダーの初期化
         Calendar calendar = Calendar.getInstance();
         calendar.set(year, month, 1);
         int firstDay = 0;
+
         BusyData[] busys = new BusyData[43];
         for (int h = 0; h < 42; h++) {
             busys[h] = new BusyData();
@@ -387,6 +411,7 @@ public class CalendarActivity extends AppCompatActivity {
                 LinearLayout.LayoutParams.MATCH_PARENT,
                 LinearLayout.LayoutParams.MATCH_PARENT
         ));
+        scheduleLayout.removeAllViews();
         scheduleLayout.setOrientation(LinearLayout.VERTICAL);
 
         // 日付からスケジュールを取得
@@ -395,11 +420,12 @@ public class CalendarActivity extends AppCompatActivity {
             if (date != null) {
                 int dateId = date.getId();
                 addScheduleById(dateId, linearLayout, dateButton, scheduleLayout, year, month, day, busys, cell);
+            }else{
+                viewBusy(busys);
             }
         });
 
         //繰り返しの予定
-        /*
         String[] repeatOptions = {"毎週", "隔週", "毎月"};
         for (String repeatOption : repeatOptions) {
             LiveData<List<Schedule>> repeatScheduleLiveData = scheduleViewModel.getSchedulesByRepeat(repeatOption);
@@ -438,20 +464,17 @@ public class CalendarActivity extends AppCompatActivity {
                     }
                 }
             });
-        }*/
-
+        }
 
         // 読み込み終了後、ロック解除
         binding.progressBar.setVisibility(View.GONE);  // ローディング表示終了
         binding.lastMonthButton.setEnabled(true);      // ボタン再有効化
         binding.nextMonthButton.setEnabled(true);
-        viewBusy(busys);
     }
 
     // 予定の表示(idで実行)
     private void addScheduleById(int id, LinearLayout linearLayout, Button dateButton, LinearLayout scheduleLayout, int year, int month, int day, BusyData busys[], int cell) {
-        LiveData<List<Schedule>> scheduleLiveData = scheduleViewModel.getSchedulesByDateId(id);
-        scheduleLiveData.observe(this, schedules -> {
+        observeOnce(scheduleViewModel.getSchedulesByDateId(id), schedules -> {
                     if (schedules != null) {
 
                         BottomSheetDialog bottomSheetDialog = new BottomSheetDialog(this);
@@ -469,9 +492,6 @@ public class CalendarActivity extends AppCompatActivity {
                             bottomSheetDialog.dismiss();
                         });
 
-                        scheduleLayout.removeAllViews();
-                        scheduleContainer.removeAllViews();
-
                         int countSchedule = -3;
 
                         for (Schedule schedule : schedules) {
@@ -484,11 +504,10 @@ public class CalendarActivity extends AppCompatActivity {
                             String eventColor = schedule.getColor();
                             String memo = schedule.getMemo();
 
-                            Log.d(TAG, "Schedule By ID: " + title + schedule.getId());
+                            Log.d(TAG, "Schedule By ID[" + cell + "]: " + title + " id: " + schedule.getId());
 
                             //忙しさの表示
                             busys[cell].setBusy(strong);
-                            viewBusy(busys);
 
                             // カレンダー表示用テキストビューを生成
                             if (countSchedule < 0) {
@@ -602,14 +621,20 @@ public class CalendarActivity extends AppCompatActivity {
                                 AlertDialog.Builder builder2 = new AlertDialog.Builder(this);
                                 builder2.setTitle("予定を削除しますか？")
                                         .setPositiveButton("削除", (dialog2, which) -> {
-                                            // 削除し、ダイアログを閉じる
+
+                                            Log.d(TAG, "delete:" + schedule.getTitle());
+
                                             scheduleViewModel.delete(schedule);
 
-                                            // ダイアログを閉じる
                                             bottomSheetDialog.dismiss();
 
-                                            // UIを即時更新
-                                            refreshCalendarData(year, month);
+                                            Intent resultIntent = new Intent(CalendarActivity.this, CalendarActivity.class);
+                                            resultIntent.putExtra("selectedYear", year);
+                                            resultIntent.putExtra("selectedMonth", month);
+                                            resultIntent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
+                                            startActivity(resultIntent);
+                                            finish(); // 画面を閉じる
+
                                         })
                                         .setNegativeButton("キャンセル", (dialog2, which) -> {
                                             // ダイアログを閉じる
@@ -684,12 +709,14 @@ public class CalendarActivity extends AppCompatActivity {
                         linearLayout.addView(frameLayout);
 
                     }else{
-                        LiveData<Date> livedate = dateViewModel.getDateById(id);
-                        livedate.observe(this, date -> {
-                            dateViewModel.delete(date);
+                        observeOnce(dateViewModel.getDateById(id), date -> {
+                            if (date != null) {
+                                dateViewModel.delete(date);
+                            }
                         });
                     }
-                });
+            viewBusy(busys);
+        });
     }
 
     //デフォルトの忙しさ反映(当月の曜日走査)
@@ -735,6 +762,7 @@ public class CalendarActivity extends AppCompatActivity {
                 busy = busydata[i].getBusy() + (busydata[i-1].getBusy()+busydata[i+1].getBusy())/2;
             }
             busy += busydata[i].getDefaultBusy();
+            if(busy != 0){Log.d(TAG, "viewBusy[ " + i + "]:"+ busy);}
             if(busy > 7){busy = 7;}
             if(busy < 0){busy = 0;}
             switch (busy) {
@@ -750,6 +778,7 @@ public class CalendarActivity extends AppCompatActivity {
             }
             if(busydata[i].getGray() == true){
                 ll.setBackgroundResource(R.drawable.borderx);
+                if(busy != 0){Log.d(TAG, "viewBusy[ " + i + "]:grey");}
             }
         }
     }
@@ -764,5 +793,15 @@ public class CalendarActivity extends AppCompatActivity {
             case 1 : return "①";
         }
         return "";
+    }
+
+    private <T> void observeOnce(LiveData<T> liveData, Observer<T> observer) {
+        liveData.observe(this, new Observer<T>() {
+            @Override
+            public void onChanged(T t) {
+                observer.onChanged(t);
+                liveData.removeObserver(this);
+            }
+        });
     }
 }

--- a/app/src/main/java/io/github/shun/osugi/busible/ui/EditScheduleActivity.java
+++ b/app/src/main/java/io/github/shun/osugi/busible/ui/EditScheduleActivity.java
@@ -148,6 +148,12 @@ public class EditScheduleActivity extends AppCompatActivity {
                         dateLiveData.observe(this, date -> {
                             int dateId = getOrMakeDateId(dateViewModel, date);
                             updateSchedule(scheduleViewModel, schedule, dateId, title, memo, strong, startTime, endTime, selectedColor, repeatOption);
+                            dateLiveData.removeObservers(this);
+                            // 保存処理の最後にカレンダー更新用のデータを渡す
+                            Intent resultIntent = new Intent(EditScheduleActivity.this, CalendarActivity.class);
+                            resultIntent.putExtra("selectedYear", selectedYear);
+                            resultIntent.putExtra("selectedMonth", selectedMonth);
+                            startActivity(resultIntent);
                             finish(); // 画面を閉じる
                         });
                     } else {


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

## 概要

<!-- 変更の目的 もしくは 関連する Issue 番号 -->
- #145 

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- 予定追加、編集、削除時にて、画面遷移をするように挙動を変更
- 予定追加、編集画面からカレンダー画面に遷移する際に、そのとき選択された年月のカレンダーを表示するように変更

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->
- カレンダー画面への遷移の際に、選択された年月をIntentに渡すように変更している
- なお、値が指定されていない場合は、現在の年月となる

## 動作要件

<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
- 影響範囲参照

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
- この変更により、予定追加、変更、削除後の二重表示、繰り返しとのviewの競合は解決しているが、繰り返しの予定がある日の全ての予定が繰り返されてしまう問題については、繰り返し予定の表示アルゴリズムの変更が必要だと思われるため、未着手である