### PR TITLE
予定のない日にダイアログが表示されないよう修正

### DIFF
--- a/app/src/main/java/io/github/shun/osugi/busible/ui/CalendarActivity.java
+++ b/app/src/main/java/io/github/shun/osugi/busible/ui/CalendarActivity.java
@@ -232,8 +232,19 @@ public class CalendarActivity extends AppCompatActivity {
     // 日付から予定の有無を判断し、日付毎のレイアウトを生成
     private void searchDateData(LinearLayout linearLayout, int year, int month, int day, BusyData busys[], int cell) {
 
+        // 各日のスケジュール数の記録
+        Integer[] numSchedules = new Integer[42];
+        for (int h = 0; h < 42; h++) {
+            numSchedules[h] = 0;
+        }
+
         // ダイアログボタン用のフレームを生成
         FrameLayout frameLayout = new FrameLayout(this);
+        LinearLayout.LayoutParams frameLayoutParams = new LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                LinearLayout.LayoutParams.WRAP_CONTENT
+        );
+        frameLayout.setLayoutParams(frameLayoutParams);
         linearLayout.addView(frameLayout);
 
         // 予定超過数を表示するテキストを生成
@@ -268,14 +279,11 @@ public class CalendarActivity extends AppCompatActivity {
         bottomSheetDialog.setCanceledOnTouchOutside(true);
 
         dateButton.setOnClickListener(showDialog -> {
-            bottomSheetDialog.show();
+            if (numSchedules[cell] > 0) {
+                bottomSheetDialog.show();
+            }
         });
         dateButton.bringToFront();
-
-        Integer[] numSchedules = new Integer[42];
-        for (int h = 0; h < 42; h++) {
-            numSchedules[h] = 0;
-        }
 
         // 予定の取得
         observeOnce(dateViewModel.getDateBySpecificDay(year, month, day), date -> {


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

## 概要

<!-- 変更の目的 もしくは 関連する Issue 番号 -->
- #98

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- ボトムシートダイアログを表示するボタンを押したときに、予定がある場合のみダイアログを表示するように変更（各日の予定数を参照）

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->
- x

## 動作要件

<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
- x

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
- x