### PR TITLE
[add] #98 繰り返しの一部削除に対応

### DIFF
--- a/app/src/main/java/io/github/shun/osugi/busible/dao/RepeatExclusionDao.java
+++ b/app/src/main/java/io/github/shun/osugi/busible/dao/RepeatExclusionDao.java
@@ -1,5 +1,6 @@
 package io.github.shun.osugi.busible.dao;
 
+import androidx.lifecycle.LiveData;
 import androidx.room.Dao;
 import androidx.room.Insert;
 import androidx.room.Delete;
@@ -17,6 +18,6 @@ public interface RepeatExclusionDao {
     void delete(RepeatExclusion exclusion);
 
     @Query("SELECT * FROM repeat_exclusion WHERE repeatId = :repeatId")
-    List<RepeatExclusion> getExclusionsForRepeat(int repeatId);
+    LiveData<List<RepeatExclusion>> getExclusionsForRepeat(int repeatId);
 }
 

--- a/app/src/main/java/io/github/shun/osugi/busible/viewmodel/RepeatExclusionViewModel.java
+++ b/app/src/main/java/io/github/shun/osugi/busible/viewmodel/RepeatExclusionViewModel.java
@@ -4,6 +4,7 @@ import android.app.Application;
 
 import androidx.annotation.NonNull;
 import androidx.lifecycle.AndroidViewModel;
+import androidx.lifecycle.LiveData;
 
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -32,7 +33,7 @@ public class RepeatExclusionViewModel extends AndroidViewModel {
         executorService.execute(() -> repeatExclusionDao.delete(exclusion));
     }
 
-    public List<RepeatExclusion> getExclusionsForRepeat(int repeatId) {
+    public LiveData<List<RepeatExclusion>> getExclusionsForRepeat(int repeatId) {
         return repeatExclusionDao.getExclusionsForRepeat(repeatId);
     }
 }


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

## 概要

<!-- 変更の目的 もしくは 関連する Issue 番号 -->
- #98 

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- 繰り返しの一部削除に対応
- 繰り返し予定の表示は通常予定の表示時には行わず、開始日含め繰り返し予定の表示時に行うように変更
- 繰り返しの予定を削除した場合には、繰り返し除外データベースに日時を登録することで、表示から除外

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->
- x

## 動作要件

<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
- x

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
- たまに、開始日が表示されないときがある