### PR TITLE
[fix] #159 予定編集を現在の予定追加に合わせたものとした

### DIFF
--- a/app/src/main/java/io/github/shun/osugi/busible/dao/RepeatDao.java
+++ b/app/src/main/java/io/github/shun/osugi/busible/dao/RepeatDao.java
@@ -30,9 +30,9 @@ public interface RepeatDao {
     @Query("SELECT * FROM repeat WHERE id = :id")
     LiveData<Repeat> getRepeatById(int id);
 
-    // 特定の scheduleId を持つ繰り返しデータを取得
-    //@Query("SELECT * FROM repeat WHERE scheduleId = :scheduleId")
-    //LiveData<List<Repeat>> getRepeatsByScheduleId(int scheduleId);
+    //特定の scheduleId を持つ繰り返しデータを取得
+    @Query("SELECT * FROM repeat WHERE scheduleId = :scheduleId")
+    LiveData<List<Repeat>> getRepeatsByScheduleId(int scheduleId);
 
     // 特定の dateId を持つ繰り返しデータを取得
     //@Query("SELECT * FROM repeat WHERE dateId = :dateId")

--- a/app/src/main/java/io/github/shun/osugi/busible/ui/AddScheduleActivity.java
+++ b/app/src/main/java/io/github/shun/osugi/busible/ui/AddScheduleActivity.java
@@ -125,7 +125,6 @@ public class AddScheduleActivity extends AppCompatActivity {
         binding.colorBlue.setOnClickListener(v -> setColorAndCheck("#0000FF", binding.checkBlue));
         binding.colorPurple.setOnClickListener(v -> setColorAndCheck("#8F35B5", binding.checkPurple));
         binding.colorOrange.setOnClickListener(v -> setColorAndCheck("#FF6C00", binding.checkOrange));
-        binding.colorWhite.setOnClickListener(v -> setColorAndCheck("#FFFFFF", binding.checkWhite));
 
         // 初期状態で保存ボタンの色を薄くする
         binding.save.setTextColor(Color.parseColor("#B0B0B0")); // 無効化時の色
@@ -283,15 +282,16 @@ public class AddScheduleActivity extends AppCompatActivity {
             Repeat repeat = new Repeat();
             repeat.setDateId(dateId); // dateId
             repeat.setScheduleId(scheduleId); // ScheduleのIDを設定
-            if (repeatOption == "毎週"){
-                repeat.setRepeat(Dow);
-            }else if (repeatOption == "隔週"){
-                repeat.setRepeat(week * (-1));
-            } else if (repeatOption == "毎月") {
-                repeat.setRepeat(selectedDay);
-            }else {
-                repeat.setRepeat(0);
-            }
+        if (repeatOption.equals("毎週")) {
+            repeat.setRepeat(Dow);
+        } else if (repeatOption.equals("隔週")) {
+            repeat.setRepeat(week * (-1));
+        } else if (repeatOption.equals("毎月")) {
+            repeat.setRepeat(selectedDay);
+        } else {
+            repeat.setRepeat(0);
+        }
+
         repeatViewModel.insert(repeat);
 
             Log.d(TAG, "Repeat saved:" + repeatOption + " ," + repeat.getRepeat());
@@ -418,7 +418,6 @@ public class AddScheduleActivity extends AppCompatActivity {
         binding.checkBlue.setVisibility(View.GONE);
         binding.checkPurple.setVisibility(View.GONE);
         binding.checkOrange.setVisibility(View.GONE);
-        binding.checkWhite.setVisibility(View.GONE);
 
         // 選択した色のチェックマークを表示
         selectedCheck.setVisibility(View.VISIBLE);
@@ -431,7 +430,6 @@ public class AddScheduleActivity extends AppCompatActivity {
         binding.colorBlue.setAlpha(color.equals("#0000FF") ? 1.0f : 0.5f);
         binding.colorPurple.setAlpha(color.equals("#8F35B5") ? 1.0f : 0.5f);
         binding.colorOrange.setAlpha(color.equals("#FF6C00") ? 1.0f : 0.5f);
-        binding.colorWhite.setAlpha(color.equals("#FFFFFF") ? 1.0f : 0.5f);
     }
 
 

--- a/app/src/main/java/io/github/shun/osugi/busible/viewmodel/RepeatViewModel.java
+++ b/app/src/main/java/io/github/shun/osugi/busible/viewmodel/RepeatViewModel.java
@@ -13,6 +13,7 @@ import java.util.concurrent.Executors;
 import io.github.shun.osugi.busible.database.AppDatabase;
 import io.github.shun.osugi.busible.dao.RepeatDao;
 import io.github.shun.osugi.busible.entity.Repeat;
+import io.github.shun.osugi.busible.entity.Schedule;
 
 public class RepeatViewModel extends AndroidViewModel {
     private final RepeatDao repeatDao;
@@ -43,6 +44,11 @@ public class RepeatViewModel extends AndroidViewModel {
 
     public LiveData<Repeat> getRepeatById(int id) {
         return repeatDao.getRepeatById(id);
+    }
+
+    // scheduleIdでスケジュールを取得
+    public LiveData<List<Repeat>> getRepeatByScheduleId(int id) {
+        return repeatDao.getRepeatsByScheduleId(id);
     }
 
     }

--- a/app/src/main/res/drawable/check_icon.xml
+++ b/app/src/main/res/drawable/check_icon.xml
@@ -4,6 +4,6 @@
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path
-        android:fillColor="@android:color/black"
+        android:fillColor="@android:color/white"
         android:pathData="M9,16.2l-4.2,-4.2l-1.4,1.4l5.6,5.6l12,-12l-1.4,-1.4z"/>
 </vector>

--- a/app/src/main/res/layout/activity_add_schedule.xml
+++ b/app/src/main/res/layout/activity_add_schedule.xml
@@ -152,27 +152,6 @@
                 android:visibility="gone"/> <!-- 初期状態は非表示 -->
 
         </FrameLayout>
-
-        <FrameLayout
-            android:layout_width="40dp"
-            android:layout_height="40dp"
-            android:layout_marginStart="10dp">
-
-            <Button
-                android:id="@+id/color_white"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:backgroundTint="#FFFFFF"
-                android:tag="#FFFFFF" />
-
-            <ImageView
-                android:id="@+id/checkWhite"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:src="@drawable/check_icon"
-                android:visibility="gone"/> <!-- 初期状態は非表示 -->
-
-        </FrameLayout>
     </LinearLayout>
 
 


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

## 概要

<!-- 変更の目的 もしくは 関連する Issue 番号 -->
- 159

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- 予定編集変更
- 予定背景色の白色を削除
- 予定背景色の選択時のチェックの色を白に変更

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->
- x

## 動作要件

<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
- x

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
- x