### PR TITLE
[add] #135 単色モードの追加及びプライバシーポリシーへのリンクの追加、隔週のコメントアウト

### DIFF
--- a/app/src/main/java/io/github/shun/osugi/busible/ui/AddScheduleActivity.java
+++ b/app/src/main/java/io/github/shun/osugi/busible/ui/AddScheduleActivity.java
@@ -81,7 +81,7 @@ public class AddScheduleActivity extends AppCompatActivity {
         binding.spinnerNumber.setDisplayedValues(strongOptions);
         binding.spinnerNumber.setWrapSelectorWheel(true);
 
-        String[] repeatOptions = {"なし", "毎週", "隔週", "毎月"};
+        String[] repeatOptions = {"なし", "毎週"/*, "隔週"*/, "毎月"};
         binding.answer.setMinValue(0);
         binding.answer.setMaxValue(repeatOptions.length - 1);
         binding.answer.setDisplayedValues(repeatOptions);

--- a/app/src/main/java/io/github/shun/osugi/busible/ui/CalendarActivity.java
+++ b/app/src/main/java/io/github/shun/osugi/busible/ui/CalendarActivity.java
@@ -2,6 +2,7 @@ package io.github.shun.osugi.busible.ui;
 
 import android.app.AlertDialog;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.graphics.Color;
 import android.graphics.Point;
 import android.graphics.Typeface;
@@ -906,6 +907,8 @@ public class CalendarActivity extends AppCompatActivity {
     private int viewBusy(BusyData[] busydata, int i) {
         int busy;
         LinearLayout ll = findViewById(i);
+        SharedPreferences preferences = getSharedPreferences("AppSettings", MODE_PRIVATE);
+        boolean isColorTypeSwitchChecked = preferences.getBoolean("colorTypeSwitch", false);
         if(i == 0){
             busy = busydata[i].getBusy() + busydata[i+1].getBusy()/3;
         } else if (i == 41) {
@@ -917,16 +920,30 @@ public class CalendarActivity extends AppCompatActivity {
         if(busy != 0){Log.d(TAG, "viewBusy[ " + i + "]:"+ busy);}
         if(busy > 7){busy = 7;}
         if(busy < 0){busy = 0;}
-        switch (busy) {
-            case 7 -> ll.setBackgroundResource(R.drawable.border7);
-            case 6 -> ll.setBackgroundResource(R.drawable.border6);
-            case 5 -> ll.setBackgroundResource(R.drawable.border5);
-            case 4 -> ll.setBackgroundResource(R.drawable.border4);
-            case 3 -> ll.setBackgroundResource(R.drawable.border3);
-            case 2 -> ll.setBackgroundResource(R.drawable.border2);
-            case 1 -> ll.setBackgroundResource(R.drawable.border1);
-            case 0 -> ll.setBackgroundResource(R.drawable.border0);
-            default -> ll.setBackgroundResource(R.drawable.borderx);
+        if (isColorTypeSwitchChecked) {
+            switch (busy) {
+                case 7 -> ll.setBackgroundResource(R.drawable.border7_mono);
+                case 6 -> ll.setBackgroundResource(R.drawable.border6_mono);
+                case 5 -> ll.setBackgroundResource(R.drawable.border5_mono);
+                case 4 -> ll.setBackgroundResource(R.drawable.border4_mono);
+                case 3 -> ll.setBackgroundResource(R.drawable.border3_mono);
+                case 2 -> ll.setBackgroundResource(R.drawable.border2_mono);
+                case 1 -> ll.setBackgroundResource(R.drawable.border1_mono);
+                case 0 -> ll.setBackgroundResource(R.drawable.border0_mono);
+                default -> ll.setBackgroundResource(R.drawable.borderx_mono);
+            }
+        }else {
+            switch (busy) {
+                case 7 -> ll.setBackgroundResource(R.drawable.border7);
+                case 6 -> ll.setBackgroundResource(R.drawable.border6);
+                case 5 -> ll.setBackgroundResource(R.drawable.border5);
+                case 4 -> ll.setBackgroundResource(R.drawable.border4);
+                case 3 -> ll.setBackgroundResource(R.drawable.border3);
+                case 2 -> ll.setBackgroundResource(R.drawable.border2);
+                case 1 -> ll.setBackgroundResource(R.drawable.border1);
+                case 0 -> ll.setBackgroundResource(R.drawable.border0);
+                default -> ll.setBackgroundResource(R.drawable.borderx);
+            }
         }
         if(busydata[i].getGray() == true){
             ll.setBackgroundResource(R.drawable.borderx);

--- a/app/src/main/java/io/github/shun/osugi/busible/ui/EditScheduleActivity.java
+++ b/app/src/main/java/io/github/shun/osugi/busible/ui/EditScheduleActivity.java
@@ -89,7 +89,7 @@ public class EditScheduleActivity extends AppCompatActivity {
                 binding.spinnerNumber.setDisplayedValues(strongOptions);
                 binding.spinnerNumber.setWrapSelectorWheel(true);
 
-                String[] repeatOptions = {"なし", "毎週", "隔週", "毎月"};
+                String[] repeatOptions = {"なし", "毎週"/*, "隔週"*/, "毎月"};
                 binding.answer.setMinValue(0);
                 binding.answer.setMaxValue(repeatOptions.length - 1);
                 binding.answer.setDisplayedValues(repeatOptions);

--- a/app/src/main/java/io/github/shun/osugi/busible/ui/SettingActivity.java
+++ b/app/src/main/java/io/github/shun/osugi/busible/ui/SettingActivity.java
@@ -1,12 +1,13 @@
 package io.github.shun.osugi.busible.ui;
 
 import android.annotation.SuppressLint;
+import android.content.SharedPreferences;
 import android.content.res.ColorStateList;
-import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.GradientDrawable;
 import android.os.Bundle;
 
+import android.text.method.LinkMovementMethod;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.ImageButton;
@@ -141,10 +142,30 @@ public class SettingActivity extends AppCompatActivity {
             public void onStopTrackingTouch(SeekBar seekBar) {}
         });
 
+        SharedPreferences preferences = getSharedPreferences("AppSettings", MODE_PRIVATE);
+        boolean wasChecked = preferences.getBoolean("colorTypeSwitch", false); // デフォルト値は false
+        binding.colorTypeSwitch.setChecked(wasChecked);
+
+        binding.colorTypeSwitch.setOnCheckedChangeListener((buttonView, isChecked) -> {
+            saveColorTypeSetting(isChecked);
+        });
+
+        // プライバシーポリシーへ飛ぶリンクを設定
+        TextView linkText = findViewById(R.id.linkText);
+        String textWithLink = "<a href='https://sites.google.com/ccmailg.meijo-u.ac.jp/privacy-policy'>こちら</a>";
+        linkText.setText(HtmlCompat.fromHtml(textWithLink, HtmlCompat.FROM_HTML_MODE_LEGACY));
+        linkText.setMovementMethod(LinkMovementMethod.getInstance());
+
         // 「？」ボタンのクリックイベントを設定
         ImageButton helpButton = findViewById(R.id.help_button);
         helpButton.setOnClickListener(view -> {
             showHelpDialog(0);
+        });
+
+        // 「？」ボタンのクリックイベントを設定
+        ImageButton helpButton2 = findViewById(R.id.help_button2);
+        helpButton2.setOnClickListener(view -> {
+            showHelpDialog2(0);
         });
     }
 
@@ -155,7 +176,7 @@ public class SettingActivity extends AppCompatActivity {
 
         for (int i = 0; i <= 7; i++) {
             @SuppressLint("UseCompatLoadingForDrawables") Drawable drawable = getResources().getDrawable(
-                    getResources().getIdentifier("border" + i, "drawable", getPackageName()));
+                    getResources().getIdentifier("border" + i + (binding.colorTypeSwitch.isChecked() ? "_mono" : ""), "drawable", getPackageName()));
 
             if (drawable instanceof GradientDrawable gradientDrawable) {
                 // Extracting color from GradientDrawable
@@ -167,43 +188,26 @@ public class SettingActivity extends AppCompatActivity {
             }
         }
 
-// ヘルプ情報をリストで定義
+        // ヘルプ情報をリストで定義
         List<String> helpPages = Arrays.asList(
                 "<b>デフォルト強度</b><br><br>" +
                         "　各曜日にあらかじめ設定しておける強度の値のことです。<br>" +
-                        "　強度の値を設定することで、カレンダーの背景色が次のルールに基づいて変化します。",
-                "<b>1. 設定できる範囲</b><br><br>" +
-                        "　強度は各曜日に対して <font color='blue'>-3 から +3</font> の範囲で設定可能です。<br>"+
-                        "　また、背景色を単色バージョンか多色バージョンかを選ぶことができます。背景色のルールと具体例は、選択したバージョンの方を選んでください。",
-                "<b>2. 背景色のルール(多色バージョン)</b><br><br>"+
-                        "強度7 :<font color='purple'> 紫色</font><br>" +
-                        "強度6 :<font color='red'> 赤色</font><br>" +
-                        "強度5 :<font color='#FFA500'> オレンジ色</font><br>" +
-                        "強度4 :<font color='#FFD700'> 黄色</font><br>" +
-                        "強度3 :<font color='green'> 黄緑色</font><br>" +
-                        "強度2 :<font color='#006400'> 緑色</font><br>" +
-                        "強度1 :<font color='#1E90FF'> 水色</font><br>" +
-                        "強度その他 :<font color='gray'> 灰色</font>",
-                "<b>3. 具体例</b><br><br>" +
+                        "　強度の値を設定することで、カレンダーの背景色が次のルールに基づいて変化します。<br>" +
+                        "　強度は各曜日に対して <font color='blue'>-3 から +3</font> の範囲で設定可能です。",
+                "<b>強度と背景色の対応</b><br><br>" +
+                        "<font color='" + colorMap.get(7) + "'>強度7</font><br>" +
+                        "<font color='" + colorMap.get(6) + "'>強度6</font><br>" +
+                        "<font color='" + colorMap.get(5) + "'>強度5</font><br>" +
+                        "<font color='" + colorMap.get(4) + "'>強度4</font><br>" +
+                        "<font color='" + colorMap.get(3) + "'>強度3</font><br>" +
+                        "<font color='" + colorMap.get(2) + "'>強度2</font><br>" +
+                        "<font color='" + colorMap.get(1) + "'>強度1</font><br>" +
+                        "<font color='grey'>強度その他</font>",
+                "<b>具体例</b><br><br>" +
                         "　例えば、前後日の強度を0と仮定し、月曜日のデフォルト強度を<b><font color='blue'>+3</font></b> と設定して" +
-                        "月曜日に<font color='#FFD700'> 強度4</font>の予定を入れると、<b>強度が7</b> となり背景色が<font color='purple'>紫色</font>に変化します。<br><br>" +
+                        "月曜日に<font color='"+colorMap.get(4) + "'>強度4</font>の予定を入れると、最終的な月曜日の強度は<font color='" + colorMap.get(7) + "'>強度7</font>になります。<br><br>" +
                         "　逆に、同じ条件で月曜日のデフォルト強度を<b><font color='blue'>-3</font></b> と設定して" +
-                        "月曜日に<font color='#FFD700'> 強度4</font>の予定を入れると、<b>強度が1</b> となり背景色が<font color='#1E90FF'>水色</font>となります。",
-
-                "<b>2. 背景色のルール(単色バージョン)</b><br><br>" +
-                        "強度7 :<font color='" + colorMap.get(7) + "'> 紫色</font><br>" +
-                        "強度6 :<font color='" + colorMap.get(6) + "'> 赤色</font><br>" +
-                        "強度5 :<font color='" + colorMap.get(5) + "'> オレンジ色</font><br>" +
-                        "強度4 :<font color='" + colorMap.get(4) + "'> 黄色</font><br>" +
-                        "強度3 :<font color='" + colorMap.get(3) + "'> 黄緑色</font><br>" +
-                        "強度2 :<font color='" + colorMap.get(2) + "'> 緑色</font><br>" +
-                        "強度1 :<font color='" + colorMap.get(1) + "'> 水色</font><br>" +
-                        "強度その他 :<font color='grey'> 灰色</font>",
-                "<b>3. 具体例</b><br><br>" +
-                        "　例えば、前後日の強度を0と仮定し、月曜日のデフォルト強度を<b><font color='blue'>+3</font></b> と設定して" +
-                        "月曜日に<font color='"+colorMap.get(4) + "'>強度4</font>の予定を入れると、<b>強度が7</b> となり背景色が<font color='" + colorMap.get(7) + "'>紫色</font>に変化します。<br><br>" +
-                        "　逆に、同じ条件で月曜日のデフォルト強度を<b><font color='blue'>-3</font></b> と設定して" +
-                        "月曜日に<font color='"+colorMap.get(4) + "'>強度4</font>の予定を入れると、<b>強度が1</b> となり背景色が<font color='" + colorMap.get(1) + "'>水色</font>となります。"
+                        "月曜日に<font color='"+colorMap.get(4) + "'>強度4</font>の予定を入れると、最終的な月曜日の強度は<font color='" + colorMap.get(1) + "'>強度1</font>になります。"
         );
 
         // ダイアログのビューをカスタマイズ
@@ -224,19 +228,6 @@ public class SettingActivity extends AppCompatActivity {
             builder.setNegativeButton("前へ", (dialog, which) -> {
                 showHelpDialog(pageIndex - 1); // 前のページへ
             });
-            if(pageIndex==1){
-                builder.setNegativeButton("単色バージョン", (dialog, which) -> {
-                    showHelpDialog(pageIndex+3); // 単色バージョンのページへ
-                });
-                builder.setPositiveButton("多色バージョン", (dialog, which) -> {
-                    showHelpDialog(pageIndex+1); // 多色バージョンのページへ
-                });
-            }
-            if(pageIndex==4){
-                builder.setNegativeButton("前へ", (dialog, which) -> {
-                    showHelpDialog(pageIndex-3); // 単色バージョンのページへ
-                });
-            }
             if(pageIndex==3){
                 builder.setPositiveButton("閉じる", (dialog, which) -> {
                     dialog.dismiss(); // ダイアログを閉じる
@@ -249,5 +240,88 @@ public class SettingActivity extends AppCompatActivity {
         builder.create().show();
     }
 
+    // ヘルプ情報を表示するメソッド
+    private void showHelpDialog2(int pageIndex) {
+        // 色のマッピング
+        Map<Integer, String> colorMap = new HashMap<>();
+        Map<Integer, String> colorMap_mono = new HashMap<>();
+
+        for (int i = 0; i <= 7; i++) {
+            @SuppressLint("UseCompatLoadingForDrawables") Drawable drawable = getResources().getDrawable(
+                    getResources().getIdentifier("border" + i , "drawable", getPackageName()));
+
+            if (drawable instanceof GradientDrawable gradientDrawable) {
+                // Extracting color from GradientDrawable
+                ColorStateList colorStateList = gradientDrawable.getColor();
+                if (colorStateList != null) {
+                    int color = colorStateList.getDefaultColor();
+                    colorMap.put(i, String.format("#%06X", (0xFFFFFF & color))); // Convert to #RRGGBB
+                }
+            }
+
+            @SuppressLint("UseCompatLoadingForDrawables") Drawable drawable_mono = getResources().getDrawable(
+                    getResources().getIdentifier("border" + i + "_mono", "drawable", getPackageName()));
+
+            if (drawable_mono instanceof GradientDrawable gradientDrawable) {
+                // Extracting color from GradientDrawable
+                ColorStateList colorStateList_mono = gradientDrawable.getColor();
+                if (colorStateList_mono != null) {
+                    int color = colorStateList_mono.getDefaultColor();
+                    colorMap_mono.put(i, String.format("#%06X", (0xFFFFFF & color))); // Convert to #RRGGBB
+                }
+            }
+        }
+
+        // ヘルプ情報をリストで定義
+        List<String> helpPages2 = Arrays.asList(
+                "<b>単色モード</b><br><br>" +
+                        "　単色モードを使用すると、カレンダーにおける予定の強度が赤色のグラデーションで表示されるようになります。<br>" +
+                        "　強度の差が分かりづらい場合や、色彩の違いを認識しづらい場合は、単色モードをONにすると認識しやすくなる可能性があります。<br>",
+                "<b>モードによる色の違い</b><br><br>" +
+                        "強度7 : <font color='" + colorMap.get(7) + "'>単色モードON  </font><font color='" + colorMap_mono.get(7) + "'>単色モードOFF</font><br>" +
+                        "強度6 : <font color='" + colorMap.get(6) + "'>単色モードON  </font><font color='" + colorMap_mono.get(6) + "'>単色モードOFF</font><br>" +
+                        "強度5 : <font color='" + colorMap.get(5) + "'>単色モードON  </font><font color='" + colorMap_mono.get(5) + "'>単色モードOFF</font><br>" +
+                        "強度4 : <font color='" + colorMap.get(4) + "'>単色モードON  </font><font color='" + colorMap_mono.get(4) + "'>単色モードOFF</font><br>" +
+                        "強度3 : <font color='" + colorMap.get(3) + "'>単色モードON  </font><font color='" + colorMap_mono.get(3) + "'>単色モードOFF</font><br>" +
+                        "強度2 : <font color='" + colorMap.get(2) + "'>単色モードON  </font><font color='" + colorMap_mono.get(2) + "'>単色モードOFF</font><br>" +
+                        "強度1 : <font color='" + colorMap.get(1) + "'>単色モードON  </font><font color='" + colorMap_mono.get(1) + "'>単色モードOFF</font><br>" +
+                        "強度その他 : <font color='grey'>モードに関わらず共通</font><br>" +
+                        "</table>"
+        );
+
+        // ダイアログのビューをカスタマイズ
+        View dialogView2 = LayoutInflater.from(this).inflate(R.layout.dialog_help, null);
+        TextView textView2 = dialogView2.findViewById(R.id.textView);
+        textView2.setText(HtmlCompat.fromHtml(helpPages2.get(pageIndex), HtmlCompat.FROM_HTML_MODE_LEGACY));
+
+        AlertDialog.Builder builder2 = new AlertDialog.Builder(this);
+        builder2.setView(dialogView2)
+                .setPositiveButton(pageIndex < helpPages2.size() - 1 ? "次へ" : "閉じる", (dialog, which) -> {
+                    if (pageIndex < helpPages2.size() - 1) {
+                        showHelpDialog2(pageIndex + 1); // 次のページへ
+                    }
+                });
+
+        // 2ページ目以降の場合、前のページに戻るボタンを追加
+        if (pageIndex > 0) {
+            builder2.setNegativeButton("前へ", (dialog, which) -> {
+                showHelpDialog(pageIndex - 1); // 前のページへ
+            });
+            builder2.setPositiveButton("閉じる", (dialog, which) -> {
+                dialog.dismiss(); // ダイアログを閉じる
+            });
+        }
+
+
+        builder2.setCancelable(true); // 外をタップして閉じられるようにする
+        builder2.create().show();
+    }
+
+    private void saveColorTypeSetting(boolean isChecked) {
+        SharedPreferences preferences = getSharedPreferences("AppSettings", MODE_PRIVATE);
+        SharedPreferences.Editor editor = preferences.edit();
+        editor.putBoolean("colorTypeSwitch", isChecked);
+        editor.apply(); // 非同期で保存
+    }
 
 }

--- a/app/src/main/res/layout/activity_setting.xml
+++ b/app/src/main/res/layout/activity_setting.xml
@@ -271,5 +271,77 @@
 
     </LinearLayout>
 
+    <LinearLayout
+        android:id="@+id/colorTypeLayout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_marginTop="24dp"
+        android:layout_marginBottom="24dp"
+        app:layout_constraintTop_toBottomOf="@+id/sliderLayout"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+
+        <TextView
+            android:id="@+id/colorTypeText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="15dp"
+            android:layout_marginStart="28dp"
+            android:layout_marginBottom="24dp"
+            android:text="単色モード"
+            android:textSize="20dp" />
+
+        <Switch
+            android:id="@+id/colorTypeSwitch"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="13dp"
+            android:layout_marginStart="28dp"
+            android:layout_marginBottom="24dp" />
+
+        <ImageButton
+            android:id="@+id/help_button2"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:layout_marginStart="28dp"
+            android:layout_marginTop="13dp"
+            android:layout_marginEnd="10dp"
+            android:background="@drawable/ic_circle_transparent" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/policyLayout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_marginBottom="24dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <TextView
+            android:id="@+id/policyText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="15dp"
+            android:layout_marginBottom="24dp"
+            android:text="プライバシーポリシーは"
+            android:textSize="16dp"
+            />
+
+        <TextView
+            android:id="@+id/linkText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="15dp"
+            android:layout_marginBottom="24dp"
+            android:text="こちら"
+            android:textSize="16dp"
+            />
+
+    </LinearLayout>
+
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

## 概要

<!-- 変更の目的 もしくは 関連する Issue 番号 -->
- #135 単色モードの追加
- #166 隔週のコメントアウト
- プライバシーポリシーへのリンクの追加

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- 設定画面にプライバシーポリシーへのリンクを追加
- 設定画面に単色モードへの切り替えスイッチを追加
- 単色モードかどうかのデータはSharedPreferencesを用いて保存
- ドロップダウン内の隔週をコメントアウト

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->
- 新たに単色モードかどうかのデータをSharedPreferencesを用いて保存するようにしたが、SQLiteの既存データベースには影響はないものと思われる

## 動作要件

<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
- x

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
- x