### PR TITLE
[fix] #159 予定編集画面での色の初期選択の適用

### DIFF
--- a/app/src/main/java/io/github/shun/osugi/busible/ui/EditScheduleActivity.java
+++ b/app/src/main/java/io/github/shun/osugi/busible/ui/EditScheduleActivity.java
@@ -144,6 +144,9 @@ public class EditScheduleActivity extends AppCompatActivity {
                     ImageView check = entry.getValue().second;
                     button.setOnClickListener(v -> setColorAndCheck(color));
                 }
+                String initialColor = schedule.getColor();
+                setColorAndCheck(initialColor);
+
 
                 // 保存ボタンのクリックイベント
                 binding.save.setOnClickListener(v -> {
@@ -420,7 +423,7 @@ public class EditScheduleActivity extends AppCompatActivity {
             binding.answer.setValue(0);
         }
 
-        setColor(initialColor);
+        setColorAndCheck(initialColor);
     }
 
     // 繰り返しスピナーの初期化メソッド


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

## 概要

<!-- 変更の目的 もしくは 関連する Issue 番号 -->
- #159

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- 予定編集画面での色の初期選択の表示を実装

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->
- 特になし

## 動作要件

<!-- 動作に必要な 環境変数 / 依存関係 / DBの更新 など -->
- 予定編集画面を開く

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
- x